### PR TITLE
feat: timestamped output filenames and model attribution in review docs

### DIFF
--- a/dist/extensions/pi-reviewer/index.js
+++ b/dist/extensions/pi-reviewer/index.js
@@ -1,15 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-function getModelLabel(model) {
-    if (!model)
-        return "unknown";
-    return `${model.provider}/${model.id}`;
-}
-function buildReviewFilename(source) {
-    const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
-    const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
-    return `pi-review-${ts}-${slug}.md`;
-}
+import { getModelLabel, buildReviewFilename, isModelInfo } from "./review-filename.js";
 import { loadContext } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase } from "../../src/core/diff-resolver.js";
 import { filterDiff } from "../../src/core/diff-filter.js";
@@ -43,6 +34,7 @@ export default function (pi) {
         description: "Review a PR diff with pi-reviewer (flags: --diff, --branch, --pr, --ssh, --ui, --dry-run)",
         async handler(args, ctx) {
             const notify = ctx.ui.notify.bind(ctx.ui);
+            const model = isModelInfo(ctx.model) ? ctx.model : undefined;
             let stopLoader = () => { };
             try {
                 const parsed = parseArgs(args);
@@ -83,11 +75,10 @@ export default function (pi) {
                         notify(warning, "warning");
                     let sshSaveTriggered = false;
                     const injectionMsg = await handleUIReview({
-                        result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model: ctx.model,
-                        saveRemote: (md) => {
+                        result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model,
+                        saveRemote: (md, filename) => {
                             sshSaveTriggered = true;
-                            const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
-                            pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review-${ts}.md" (e.g. if the root is /some/path, write to /some/path/pi-review-${ts}.md):\n\n${md}`);
+                            pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/${filename}" (e.g. if the root is /some/path, write to /some/path/${filename}):\n\n${md}`);
                         },
                     });
                     if (injectionMsg) {
@@ -122,17 +113,19 @@ export default function (pi) {
                 stopLoader = setReviewFooter(ctx, source);
                 const result = await runLocalReview({ systemPrompt, userPrompt, cwd: ctx.cwd, minSeverity: parsed.minSeverity, stopLoader, notify });
                 if (parsed.ui) {
-                    const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, model: ctx.model });
+                    const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, model });
                     if (injectionMsg)
                         pi.sendUserMessage(injectionMsg);
                     return;
                 }
                 const formatted = formatForTerminal(result);
-                const date = new Date().toISOString().replace("T", " ").slice(0, 19);
-                const modelLine = `**Model:** ${getModelLabel(ctx.model)}\n\n`;
-                const filename = buildReviewFilename(source);
-                await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(ctx.model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
-                notify(`Review saved → ${filename}`);
+                const now = new Date();
+                const date = now.toISOString().replace("T", " ").slice(0, 19);
+                const modelLine = `**Model:** ${getModelLabel(model)}\n\n`;
+                const filename = buildReviewFilename(source, now);
+                const filePath = path.join(ctx.cwd, filename);
+                await writeFile(filePath, `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
+                notify(`Review saved → ${filePath}`);
             }
             catch (error) {
                 stopLoader();

--- a/dist/extensions/pi-reviewer/index.js
+++ b/dist/extensions/pi-reviewer/index.js
@@ -1,5 +1,15 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+function getModelLabel(model) {
+    if (!model)
+        return "unknown";
+    return `${model.providerId}/${model.modelId}`;
+}
+function buildReviewFilename(source) {
+    const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+    const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+    return `pi-review-${ts}-${slug}.md`;
+}
 import { loadContext } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase } from "../../src/core/diff-resolver.js";
 import { filterDiff } from "../../src/core/diff-filter.js";
@@ -73,10 +83,11 @@ export default function (pi) {
                         notify(warning, "warning");
                     let sshSaveTriggered = false;
                     const injectionMsg = await handleUIReview({
-                        result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify,
+                        result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model: ctx.model,
                         saveRemote: (md) => {
                             sshSaveTriggered = true;
-                            pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review.md" (e.g. if the root is /some/path, write to /some/path/pi-review.md):\n\n${md}`);
+                            const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+                            pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review-${ts}.md" (e.g. if the root is /some/path, write to /some/path/pi-review-${ts}.md):\n\n${md}`);
                         },
                     });
                     if (injectionMsg) {
@@ -111,15 +122,17 @@ export default function (pi) {
                 stopLoader = setReviewFooter(ctx, source);
                 const result = await runLocalReview({ systemPrompt, userPrompt, cwd: ctx.cwd, minSeverity: parsed.minSeverity, stopLoader, notify });
                 if (parsed.ui) {
-                    const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify });
+                    const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, model: ctx.model });
                     if (injectionMsg)
                         pi.sendUserMessage(injectionMsg);
                     return;
                 }
                 const formatted = formatForTerminal(result);
                 const date = new Date().toISOString().replace("T", " ").slice(0, 19);
-                await writeFile(path.join(ctx.cwd, "pi-review.md"), `# Pi Review — ${source}\n\n> ${date}\n\n---\n\n${formatted}\n`, "utf-8");
-                notify("Review saved → pi-review.md");
+                const modelLine = `**Model:** ${getModelLabel(ctx.model)}\n\n`;
+                const filename = buildReviewFilename(source);
+                await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(ctx.model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
+                notify(`Review saved → ${filename}`);
             }
             catch (error) {
                 stopLoader();

--- a/dist/extensions/pi-reviewer/index.js
+++ b/dist/extensions/pi-reviewer/index.js
@@ -3,7 +3,7 @@ import path from "node:path";
 function getModelLabel(model) {
     if (!model)
         return "unknown";
-    return `${model.providerId}/${model.modelId}`;
+    return `${model.provider}/${model.id}`;
 }
 function buildReviewFilename(source) {
     const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);

--- a/dist/extensions/pi-reviewer/review-filename.js
+++ b/dist/extensions/pi-reviewer/review-filename.js
@@ -1,0 +1,25 @@
+/**
+ * Shared helpers for generating review output filenames and model labels.
+ * Used by index.ts, ui-handler.ts, and any future extension entry points.
+ */
+export function isModelInfo(model) {
+    return (typeof model === "object" &&
+        model !== null &&
+        "provider" in model &&
+        typeof model.provider === "string" &&
+        "id" in model &&
+        typeof model.id === "string");
+}
+export function getModelLabel(model) {
+    if (!model)
+        return "unknown";
+    return `${model.provider}/${model.id}`;
+}
+export function buildReviewFilename(source, now = new Date()) {
+    const ts = now.toISOString().replace(/[T:]/g, "-").slice(0, 19);
+    const slug = source
+        .replace(/[^a-zA-Z0-9]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "") || "untitled";
+    return `pi-review-${ts}-${slug}.md`;
+}

--- a/dist/extensions/pi-reviewer/run-ssh.js
+++ b/dist/extensions/pi-reviewer/run-ssh.js
@@ -1,5 +1,15 @@
 import { parseAgentResponse } from "../../src/core/output.js";
 import { extractLastAssistantText } from "./events.js";
+/**
+ * Starts an SSH review run by registering PI event handlers and sending the user prompt to the agent.
+ *
+ * @param opts - Configuration for the review run
+ * @param opts.systemPrompt - System-level prompt supplied to the agent before it starts
+ * @param opts.userPrompt - The user-facing message sent to the agent to trigger the review
+ * @param opts.pi - The ExtensionAPI instance used to communicate with the agent
+ * @param opts.stopLoader - Callback invoked to stop any progress/loading UI when the run completes
+ * @param opts.notify - Notification callback used to report a saved review (receives the message string)
+ */
 export function runSSHReview(opts) {
     const { systemPrompt, userPrompt, pi, stopLoader, notify } = opts;
     let done = false;
@@ -13,7 +23,7 @@ export function runSSHReview(opts) {
             return;
         done = true;
         stopLoader();
-        notify("Review saved → pi-review-<timestamp>-<source>.md");
+        notify("Review saved → <remote-project-root>/pi-review.md");
     });
     pi.sendUserMessage(userPrompt);
 }

--- a/dist/extensions/pi-reviewer/run-ssh.js
+++ b/dist/extensions/pi-reviewer/run-ssh.js
@@ -13,7 +13,7 @@ export function runSSHReview(opts) {
             return;
         done = true;
         stopLoader();
-        notify("Review saved → pi-review.md");
+        notify("Review saved → pi-review-<timestamp>-<source>.md");
     });
     pi.sendUserMessage(userPrompt);
 }

--- a/dist/extensions/pi-reviewer/ui-handler.js
+++ b/dist/extensions/pi-reviewer/ui-handler.js
@@ -36,7 +36,7 @@ export async function handleUIReview(opts) {
 function getModelLabel(model) {
     if (!model)
         return "unknown";
-    return `${model.providerId}/${model.modelId}`;
+    return `${model.provider}/${model.id}`;
 }
 function buildDecisionsMarkdown(result, decisions, source, globalComment, model) {
     const date = new Date().toISOString().replace("T", " ").slice(0, 19);

--- a/dist/extensions/pi-reviewer/ui-handler.js
+++ b/dist/extensions/pi-reviewer/ui-handler.js
@@ -1,10 +1,14 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startUIServer } from "../../src/core/ui-server.js";
+import { getModelLabel, buildReviewFilename } from "./review-filename.js";
 /**
- * Returns the injection message to send to the agent, or undefined if none.
- * Save is handled internally; the caller is responsible for sending the injection
- * message at the right time (after any agent-side save has completed).
+ * Orchestrates the interactive review UI flow and produces an agent injection message when the user requests sending.
+ *
+ * Starts a UI server for the given review, notifies the caller of the UI URL, waits for the user's action, and closes the UI.
+ * If the user chooses to save, the function will either write a timestamped markdown file into `cwd` or invoke `saveRemote` if provided.
+ *
+ * @returns A plain-text injection message for the agent if the user selected "send" or "save-and-send", `undefined` otherwise.
  */
 export async function handleUIReview(opts) {
     const { result, diff, conventions, source, ssh, cwd, notify, saveRemote } = opts;
@@ -15,17 +19,17 @@ export async function handleUIReview(opts) {
     if (action.type === "closed")
         return undefined;
     if (action.type === "save" || action.type === "save-and-send") {
-        const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model);
-        const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
-        const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
-        const filename = `pi-review-${ts}-${slug}.md`;
+        const now = new Date();
+        const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model, now);
+        const filename = buildReviewFilename(source, now);
         if (saveRemote) {
-            saveRemote(md);
-            notify(`Review save requested → ${filename} (remote)`);
+            saveRemote(md, filename);
+            notify(`Review save requested → <remote-project-root>/${filename}`);
         }
         else {
-            await writeFile(path.join(cwd, filename), md, "utf-8");
-            notify(`Review saved → ${filename}`);
+            const filePath = path.join(cwd, filename);
+            await writeFile(filePath, md, "utf-8");
+            notify(`Review saved → ${filePath}`);
         }
     }
     if (action.type === "send" || action.type === "save-and-send") {
@@ -33,13 +37,18 @@ export async function handleUIReview(opts) {
     }
     return undefined;
 }
-function getModelLabel(model) {
-    if (!model)
-        return "unknown";
-    return `${model.provider}/${model.id}`;
-}
-function buildDecisionsMarkdown(result, decisions, source, globalComment, model) {
-    const date = new Date().toISOString().replace("T", " ").slice(0, 19);
+/**
+ * Create a markdown report summarizing review results and the decisions made for a given source.
+ *
+ * @param result - The review result containing a human summary and an array of comments referenced by decisions
+ * @param decisions - Decisions for each comment (accept, reject, discuss) that determine how each comment is presented
+ * @param source - The source identifier or path to include in the report title
+ * @param globalComment - Optional overall comment to include near the top of the report
+ * @param model - Optional model metadata; when provided the report header includes `provider/id` (or `"unknown"` if absent)
+ * @returns The complete review report as a markdown-formatted string
+ */
+function buildDecisionsMarkdown(result, decisions, source, globalComment, model, now = new Date()) {
+    const date = now.toISOString().replace("T", " ").slice(0, 19);
     const modelLabel = getModelLabel(model);
     const lines = [`# Pi Review — ${source}`, ``, `> ${date} · ${modelLabel}`, ``, `**Model:** ${modelLabel}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];
     if (globalComment)

--- a/dist/extensions/pi-reviewer/ui-handler.js
+++ b/dist/extensions/pi-reviewer/ui-handler.js
@@ -15,14 +15,17 @@ export async function handleUIReview(opts) {
     if (action.type === "closed")
         return undefined;
     if (action.type === "save" || action.type === "save-and-send") {
-        const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment);
+        const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model);
+        const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+        const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+        const filename = `pi-review-${ts}-${slug}.md`;
         if (saveRemote) {
             saveRemote(md);
-            notify("Review save requested → pi-review.md (remote)");
+            notify(`Review save requested → ${filename} (remote)`);
         }
         else {
-            await writeFile(path.join(cwd, "pi-review.md"), md, "utf-8");
-            notify("Review saved → pi-review.md");
+            await writeFile(path.join(cwd, filename), md, "utf-8");
+            notify(`Review saved → ${filename}`);
         }
     }
     if (action.type === "send" || action.type === "save-and-send") {
@@ -30,9 +33,15 @@ export async function handleUIReview(opts) {
     }
     return undefined;
 }
-function buildDecisionsMarkdown(result, decisions, source, globalComment) {
+function getModelLabel(model) {
+    if (!model)
+        return "unknown";
+    return `${model.providerId}/${model.modelId}`;
+}
+function buildDecisionsMarkdown(result, decisions, source, globalComment, model) {
     const date = new Date().toISOString().replace("T", " ").slice(0, 19);
-    const lines = [`# Pi Review — ${source}`, ``, `> ${date}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];
+    const modelLabel = getModelLabel(model);
+    const lines = [`# Pi Review — ${source}`, ``, `> ${date} · ${modelLabel}`, ``, `**Model:** ${modelLabel}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];
     if (globalComment)
         lines.push("## Comment", "", globalComment, "");
     const accepted = decisions.filter((d) => d.decision !== "reject");

--- a/dist/src/core/output.js
+++ b/dist/src/core/output.js
@@ -128,6 +128,20 @@ export function formatForTerminal(result) {
     }
     return lines.join("\n");
 }
+/**
+ * Send a parsed review to the configured output target.
+ *
+ * Sends formatted review content (derived from `options.content`) to one of:
+ * - the terminal,
+ * - a GitHub PR (inline review or issue comment), or
+ * - a timestamped markdown file on disk.
+ *
+ * @param options - Configuration that specifies the review content, destination (`target`), optional minimum severity filter, and any GitHub or file settings required for the selected target.
+ * @throws Error - If `target` is `"comment"` and `githubToken` is not provided.
+ * @throws Error - If `target` is `"comment"` and `prNumber` is not a number.
+ * @throws Error - If `target` is `"comment"` and `repo` (owner/repo) is not provided.
+ * @throws Error - If posting the fallback GitHub issue comment fails (includes HTTP status and response body when available).
+ */
 export async function sendOutput(options) {
     const result = parseAgentResponse(options.content, options.minSeverity);
     if (options.target === "terminal") {

--- a/dist/src/core/output.js
+++ b/dist/src/core/output.js
@@ -188,7 +188,8 @@ export async function sendOutput(options) {
         return;
     }
     const cwd = options.cwd ?? process.cwd();
-    const filePath = path.join(cwd, "pi-review.md");
+    const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+    const filePath = path.join(cwd, `pi-review-${ts}.md`);
     await writeFile(filePath, formatForTerminal(result), "utf-8");
     console.log(`[pi-reviewer] review saved to ${filePath}`);
 }

--- a/dist/src/core/prompt-builder.js
+++ b/dist/src/core/prompt-builder.js
@@ -63,7 +63,7 @@ export function buildJSONSystemPrompt(context, minSeverity = "INFO") {
 }
 /**
  * Markdown system prompt — used by SSH-only mode.
- * Agent writes a human-readable markdown review and saves it to pi-review.md.
+ * Agent writes a human-readable markdown review and saves it to a timestamped pi-review file.
  */
 export function buildMarkdownSystemPrompt(minSeverity = "INFO") {
     return [

--- a/dist/src/core/prompt-builder.js
+++ b/dist/src/core/prompt-builder.js
@@ -62,8 +62,15 @@ export function buildJSONSystemPrompt(context, minSeverity = "INFO") {
     return sections.join("\n\n");
 }
 /**
- * Markdown system prompt — used by SSH-only mode.
- * Agent writes a human-readable markdown review and saves it to a timestamped pi-review file.
+ * Constructs a Markdown-formatted system prompt for SSH-only code review agents.
+ *
+ * The prompt instructs the agent to produce a human-readable Markdown review containing
+ * a summary section with bullet points for each issue and an inline comments section
+ * listing file, line, and comment for each finding. It also instructs the agent to
+ * save the final review to `pi-review.md` in the project root using the Write tool.
+ *
+ * @param minSeverity - The minimum severity tier to include in the review (defaults to "INFO")
+ * @returns The full system prompt as a single string
  */
 export function buildMarkdownSystemPrompt(minSeverity = "INFO") {
     return [

--- a/dist/src/core/ui/server.js
+++ b/dist/src/core/ui/server.js
@@ -31,7 +31,7 @@ export function readViewMode() {
 // The UI sends an explicit pagehide signal on tab close, so this only
 // triggers on browser crash or network drop. 45s = one missed ping + grace.
 const HEARTBEAT_MS = 45_000;
-export async function startUIServer(result, diff, source, ssh) {
+export async function startUIServer(result, diff, source, ssh, autoOpen = true) {
     const html = buildHTML(result, diff, source, ssh, readTheme(), readViewMode());
     let resolveAction;
     const actionPromise = new Promise((r) => { resolveAction = r; });
@@ -110,7 +110,8 @@ export async function startUIServer(result, diff, source, ssh) {
     const port = await listenOnRandomPort(server);
     const url = "http://localhost:" + port;
     resetHeartbeat();
-    openBrowser(url);
+    if (autoOpen)
+        openBrowser(url);
     return {
         url,
         waitForAction: () => actionPromise,

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-import { getModelLabel, buildReviewFilename } from "./review-filename.js";
+import { getModelLabel, buildReviewFilename, type ModelInfo } from "./review-filename.js";
 
 import { loadContext } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase } from "../../src/core/diff-resolver.js";
@@ -36,6 +36,7 @@ export default function (pi: ExtensionAPI): void {
     description: "Review a PR diff with pi-reviewer (flags: --diff, --branch, --pr, --ssh, --ui, --dry-run)",
     async handler(args, ctx) {
       const notify = ctx.ui.notify.bind(ctx.ui);
+      const model = ctx.model as ModelInfo;
       let stopLoader: () => void = () => {};
       try {
         const parsed = parseArgs(args);
@@ -77,7 +78,7 @@ export default function (pi: ExtensionAPI): void {
           if (warning) notify(warning, "warning");
           let sshSaveTriggered = false;
           const injectionMsg = await handleUIReview({
-            result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model: ctx.model as any,
+            result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model,
             saveRemote: (md, filename) => {
               sshSaveTriggered = true;
               pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/${filename}" (e.g. if the root is /some/path, write to /some/path/${filename}):\n\n${md}`);
@@ -114,16 +115,16 @@ export default function (pi: ExtensionAPI): void {
         const result = await runLocalReview({ systemPrompt, userPrompt, cwd: ctx.cwd, minSeverity: parsed.minSeverity, stopLoader, notify });
 
         if (parsed.ui) {
-          const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, model: ctx.model as any });
+          const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, model });
           if (injectionMsg) pi.sendUserMessage(injectionMsg);
           return;
         }
 
         const formatted = formatForTerminal(result);
-        const model = ctx.model as any;
-        const date = new Date().toISOString().replace("T", " ").slice(0, 19);
+        const now = new Date();
+        const date = now.toISOString().replace("T", " ").slice(0, 19);
         const modelLine = `**Model:** ${getModelLabel(model)}\n\n`;
-        const filename = buildReviewFilename(source);
+        const filename = buildReviewFilename(source, now);
         await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
         notify(`Review saved → ${filename}`);
       } catch (error) {

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,28 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-/**
- * Format a model identifier into a compact provider/id label.
- *
- * @param model - Object containing `provider` and `id` of a model; may be `undefined`
- * @returns The string `{provider}/{id}` when `model` is provided, or `"unknown"` when `model` is `undefined`
- */
-function getModelLabel(model: { provider: string; id: string; name?: string } | undefined): string {
-  if (!model) return "unknown";
-  return `${model.provider}/${model.id}`;
-}
-
-/**
- * Builds a timestamped, slugified markdown filename for a review based on the given source.
- *
- * @param source - Human-readable identifier for the diff or review source (e.g., branch name, PR number, or git range)
- * @returns The filename in the form `pi-review-<timestamp>-<slug>.md`, where `<timestamp>` is an ISO-like timestamp and `<slug>` is the source converted to a filesystem-friendly slug
- */
-function buildReviewFilename(source: string): string {
-  const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
-  const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
-  return `pi-review-${ts}-${slug}.md`;
-}
+import { getModelLabel, buildReviewFilename } from "./review-filename.js";
 
 import { loadContext } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase } from "../../src/core/diff-resolver.js";
@@ -99,10 +78,9 @@ export default function (pi: ExtensionAPI): void {
           let sshSaveTriggered = false;
           const injectionMsg = await handleUIReview({
             result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model: ctx.model as any,
-            saveRemote: (md) => {
+            saveRemote: (md, filename) => {
               sshSaveTriggered = true;
-              const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
-              pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review-${ts}.md" (e.g. if the root is /some/path, write to /some/path/pi-review-${ts}.md):\n\n${md}`);
+              pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/${filename}" (e.g. if the root is /some/path, write to /some/path/${filename}):\n\n${md}`);
             },
           });
           if (injectionMsg) {
@@ -142,10 +120,11 @@ export default function (pi: ExtensionAPI): void {
         }
 
         const formatted = formatForTerminal(result);
+        const model = ctx.model as any;
         const date = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const modelLine = `**Model:** ${getModelLabel(ctx.model as any)}\n\n`;
+        const modelLine = `**Model:** ${getModelLabel(model)}\n\n`;
         const filename = buildReviewFilename(source);
-        await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(ctx.model as any)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
+        await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
         notify(`Review saved → ${filename}`);
       } catch (error) {
         stopLoader();

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-import { getModelLabel, buildReviewFilename, type ModelInfo } from "./review-filename.js";
+import { getModelLabel, buildReviewFilename, isModelInfo } from "./review-filename.js";
 
 import { loadContext } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase } from "../../src/core/diff-resolver.js";
@@ -36,7 +36,7 @@ export default function (pi: ExtensionAPI): void {
     description: "Review a PR diff with pi-reviewer (flags: --diff, --branch, --pr, --ssh, --ui, --dry-run)",
     async handler(args, ctx) {
       const notify = ctx.ui.notify.bind(ctx.ui);
-      const model = ctx.model as ModelInfo;
+      const model = isModelInfo(ctx.model) ? ctx.model : undefined;
       let stopLoader: () => void = () => {};
       try {
         const parsed = parseArgs(args);
@@ -125,8 +125,9 @@ export default function (pi: ExtensionAPI): void {
         const date = now.toISOString().replace("T", " ").slice(0, 19);
         const modelLine = `**Model:** ${getModelLabel(model)}\n\n`;
         const filename = buildReviewFilename(source, now);
-        await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
-        notify(`Review saved → ${filename}`);
+        const filePath = path.join(ctx.cwd, filename);
+        await writeFile(filePath, `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(model)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
+        notify(`Review saved → ${filePath}`);
       } catch (error) {
         stopLoader();
         notify(`Review failed: ${error instanceof Error ? error.message : String(error)}`, "error");

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,11 +2,23 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+/**
+ * Format a model identifier into a compact provider/id label.
+ *
+ * @param model - Object containing `provider` and `id` of a model; may be `undefined`
+ * @returns The string `{provider}/{id}` when `model` is provided, or `"unknown"` when `model` is `undefined`
+ */
 function getModelLabel(model: { provider: string; id: string; name?: string } | undefined): string {
   if (!model) return "unknown";
   return `${model.provider}/${model.id}`;
 }
 
+/**
+ * Builds a timestamped, slugified markdown filename for a review based on the given source.
+ *
+ * @param source - Human-readable identifier for the diff or review source (e.g., branch name, PR number, or git range)
+ * @returns The filename in the form `pi-review-<timestamp>-<slug>.md`, where `<timestamp>` is an ISO-like timestamp and `<slug>` is the source converted to a filesystem-friendly slug
+ */
 function buildReviewFilename(source: string): string {
   const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
   const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,9 +2,9 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-function getModelLabel(model: { providerId: string; modelId: string } | undefined): string {
+function getModelLabel(model: { provider: string; id: string; name?: string } | undefined): string {
   if (!model) return "unknown";
-  return `${model.providerId}/${model.modelId}`;
+  return `${model.provider}/${model.id}`;
 }
 
 function buildReviewFilename(source: string): string {

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,6 +2,17 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+function getModelLabel(model: { providerId: string; modelId: string } | undefined): string {
+  if (!model) return "unknown";
+  return `${model.providerId}/${model.modelId}`;
+}
+
+function buildReviewFilename(source: string): string {
+  const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+  const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+  return `pi-review-${ts}-${slug}.md`;
+}
+
 import { loadContext } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase } from "../../src/core/diff-resolver.js";
 import { filterDiff } from "../../src/core/diff-filter.js";
@@ -75,10 +86,11 @@ export default function (pi: ExtensionAPI): void {
           if (warning) notify(warning, "warning");
           let sshSaveTriggered = false;
           const injectionMsg = await handleUIReview({
-            result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify,
+            result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify, model: ctx.model as any,
             saveRemote: (md) => {
               sshSaveTriggered = true;
-              pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review.md" (e.g. if the root is /some/path, write to /some/path/pi-review.md):\n\n${md}`);
+              const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+              pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review-${ts}.md" (e.g. if the root is /some/path, write to /some/path/pi-review-${ts}.md):\n\n${md}`);
             },
           });
           if (injectionMsg) {
@@ -112,15 +124,17 @@ export default function (pi: ExtensionAPI): void {
         const result = await runLocalReview({ systemPrompt, userPrompt, cwd: ctx.cwd, minSeverity: parsed.minSeverity, stopLoader, notify });
 
         if (parsed.ui) {
-          const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify });
+          const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, model: ctx.model as any });
           if (injectionMsg) pi.sendUserMessage(injectionMsg);
           return;
         }
 
         const formatted = formatForTerminal(result);
         const date = new Date().toISOString().replace("T", " ").slice(0, 19);
-        await writeFile(path.join(ctx.cwd, "pi-review.md"), `# Pi Review — ${source}\n\n> ${date}\n\n---\n\n${formatted}\n`, "utf-8");
-        notify("Review saved → pi-review.md");
+        const modelLine = `**Model:** ${getModelLabel(ctx.model as any)}\n\n`;
+        const filename = buildReviewFilename(source);
+        await writeFile(path.join(ctx.cwd, filename), `# Pi Review — ${source}\n\n> ${date} · ${getModelLabel(ctx.model as any)}\n\n${modelLine}---\n\n${formatted}\n`, "utf-8");
+        notify(`Review saved → ${filename}`);
       } catch (error) {
         stopLoader();
         notify(`Review failed: ${error instanceof Error ? error.message : String(error)}`, "error");

--- a/extensions/pi-reviewer/review-filename.ts
+++ b/extensions/pi-reviewer/review-filename.ts
@@ -9,6 +9,17 @@ export interface ModelInfo {
   name?: string;
 }
 
+export function isModelInfo(model: unknown): model is ModelInfo {
+  return (
+    typeof model === "object" &&
+    model !== null &&
+    "provider" in model &&
+    typeof model.provider === "string" &&
+    "id" in model &&
+    typeof model.id === "string"
+  );
+}
+
 export function getModelLabel(model: ModelInfo | undefined): string {
   if (!model) return "unknown";
   return `${model.provider}/${model.id}`;

--- a/extensions/pi-reviewer/review-filename.ts
+++ b/extensions/pi-reviewer/review-filename.ts
@@ -14,8 +14,8 @@ export function getModelLabel(model: ModelInfo | undefined): string {
   return `${model.provider}/${model.id}`;
 }
 
-export function buildReviewFilename(source: string): string {
-  const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+export function buildReviewFilename(source: string, now: Date = new Date()): string {
+  const ts = now.toISOString().replace(/[T:]/g, "-").slice(0, 19);
   const slug = source
     .replace(/[^a-zA-Z0-9]/g, "-")
     .replace(/-+/g, "-")

--- a/extensions/pi-reviewer/review-filename.ts
+++ b/extensions/pi-reviewer/review-filename.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared helpers for generating review output filenames and model labels.
+ * Used by index.ts, ui-handler.ts, and any future extension entry points.
+ */
+
+export interface ModelInfo {
+  provider: string;
+  id: string;
+  name?: string;
+}
+
+export function getModelLabel(model: ModelInfo | undefined): string {
+  if (!model) return "unknown";
+  return `${model.provider}/${model.id}`;
+}
+
+export function buildReviewFilename(source: string): string {
+  const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+  const slug = source
+    .replace(/[^a-zA-Z0-9]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "untitled";
+  return `pi-review-${ts}-${slug}.md`;
+}

--- a/extensions/pi-reviewer/run-ssh.ts
+++ b/extensions/pi-reviewer/run-ssh.ts
@@ -12,6 +12,16 @@ export interface RunSSHOptions {
   notify: (msg: string) => void;
 }
 
+/**
+ * Starts an SSH review run by registering PI event handlers and sending the user prompt to the agent.
+ *
+ * @param opts - Configuration for the review run
+ * @param opts.systemPrompt - System-level prompt supplied to the agent before it starts
+ * @param opts.userPrompt - The user-facing message sent to the agent to trigger the review
+ * @param opts.pi - The ExtensionAPI instance used to communicate with the agent
+ * @param opts.stopLoader - Callback invoked to stop any progress/loading UI when the run completes
+ * @param opts.notify - Notification callback used to report a saved review (receives the message string)
+ */
 export function runSSHReview(opts: RunSSHOptions): void {
   const { systemPrompt, userPrompt, pi, stopLoader, notify } = opts;
   let done = false;

--- a/extensions/pi-reviewer/run-ssh.ts
+++ b/extensions/pi-reviewer/run-ssh.ts
@@ -35,7 +35,7 @@ export function runSSHReview(opts: RunSSHOptions): void {
     if (done) return;
     done = true;
     stopLoader();
-    notify("Review saved → pi-review.md");
+    notify("Review saved → <remote-project-root>/pi-review.md");
   });
 
   pi.sendUserMessage(userPrompt);

--- a/extensions/pi-reviewer/run-ssh.ts
+++ b/extensions/pi-reviewer/run-ssh.ts
@@ -35,7 +35,7 @@ export function runSSHReview(opts: RunSSHOptions): void {
     if (done) return;
     done = true;
     stopLoader();
-    notify("Review saved → pi-review-<timestamp>-<source>.md");
+    notify("Review saved → pi-review.md");
   });
 
   pi.sendUserMessage(userPrompt);

--- a/extensions/pi-reviewer/run-ssh.ts
+++ b/extensions/pi-reviewer/run-ssh.ts
@@ -25,7 +25,7 @@ export function runSSHReview(opts: RunSSHOptions): void {
     if (done) return;
     done = true;
     stopLoader();
-    notify("Review saved → pi-review.md");
+    notify("Review saved → pi-review-<timestamp>-<source>.md");
   });
 
   pi.sendUserMessage(userPrompt);

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -14,6 +14,8 @@ export interface UIHandlerOptions {
   ssh?: boolean;
   /** When set, save is delegated to the remote (SSH) instead of written locally. */
   saveRemote?: (markdown: string) => void;
+  /** Current model info for review output. */
+  model?: { providerId: string; modelId: string };
 }
 
 /**
@@ -33,13 +35,16 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
   if (action.type === "closed") return undefined;
 
   if (action.type === "save" || action.type === "save-and-send") {
-    const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment);
+    const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model);
+    const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+    const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+    const filename = `pi-review-${ts}-${slug}.md`;
     if (saveRemote) {
       saveRemote(md);
-      notify("Review save requested → pi-review.md (remote)");
+      notify(`Review save requested → ${filename} (remote)`);
     } else {
-      await writeFile(path.join(cwd, "pi-review.md"), md, "utf-8");
-      notify("Review saved → pi-review.md");
+      await writeFile(path.join(cwd, filename), md, "utf-8");
+      notify(`Review saved → ${filename}`);
     }
   }
 
@@ -50,9 +55,15 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
   return undefined;
 }
 
-function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string): string {
+function getModelLabel(model: { providerId: string; modelId: string } | undefined): string {
+  if (!model) return "unknown";
+  return `${model.providerId}/${model.modelId}`;
+}
+
+function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string, model?: { providerId: string; modelId: string }): string {
   const date = new Date().toISOString().replace("T", " ").slice(0, 19);
-  const lines = [`# Pi Review — ${source}`, ``, `> ${date}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];
+  const modelLabel = getModelLabel(model);
+  const lines = [`# Pi Review — ${source}`, ``, `> ${date} · ${modelLabel}`, ``, `**Model:** ${modelLabel}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];
   if (globalComment) lines.push("## Comment", "", globalComment, "");
 
   const accepted = decisions.filter((d) => d.decision !== "reject");

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { type ReviewResult } from "../../src/core/output.js";
 import { startUIServer, type CommentDecision } from "../../src/core/ui-server.js";
+import { getModelLabel, buildReviewFilename } from "./review-filename.js";
 
 export interface UIHandlerOptions {
   result: ReviewResult;
@@ -13,7 +14,7 @@ export interface UIHandlerOptions {
   notify: (msg: string, type?: "info" | "warning" | "error") => void;
   ssh?: boolean;
   /** When set, save is delegated to the remote (SSH) instead of written locally. */
-  saveRemote?: (markdown: string) => void;
+  saveRemote?: (markdown: string, filename: string) => void;
   /** Current model info for review output. */
   model?: { provider: string; id: string; name?: string };
 }
@@ -39,11 +40,9 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
 
   if (action.type === "save" || action.type === "save-and-send") {
     const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model);
-    const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
-    const slug = source.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
-    const filename = `pi-review-${ts}-${slug}.md`;
+    const filename = buildReviewFilename(source);
     if (saveRemote) {
-      saveRemote(md);
+      saveRemote(md, filename);
       notify(`Review save requested → ${filename} (remote)`);
     } else {
       await writeFile(path.join(cwd, filename), md, "utf-8");
@@ -56,17 +55,6 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
   }
 
   return undefined;
-}
-
-/**
- * Produce a compact label for a model using its provider and id.
- *
- * @param model - Optional model metadata with `provider`, `id`, and optional `name`
- * @returns The label in the form `provider/id` if `model` is provided, otherwise `unknown`
- */
-function getModelLabel(model: { provider: string; id: string; name?: string } | undefined): string {
-  if (!model) return "unknown";
-  return `${model.provider}/${model.id}`;
 }
 
 /**

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -39,8 +39,9 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
   if (action.type === "closed") return undefined;
 
   if (action.type === "save" || action.type === "save-and-send") {
-    const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model);
-    const filename = buildReviewFilename(source);
+    const now = new Date();
+    const md = buildDecisionsMarkdown(result, action.decisions, source, action.globalComment, opts.model, now);
+    const filename = buildReviewFilename(source, now);
     if (saveRemote) {
       saveRemote(md, filename);
       notify(`Review save requested → ${filename} (remote)`);
@@ -67,8 +68,8 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
  * @param model - Optional model metadata; when provided the report header includes `provider/id` (or `"unknown"` if absent)
  * @returns The complete review report as a markdown-formatted string
  */
-function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string, model?: { provider: string; id: string; name?: string }): string {
-  const date = new Date().toISOString().replace("T", " ").slice(0, 19);
+function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string, model?: { provider: string; id: string; name?: string }, now: Date = new Date()): string {
+  const date = now.toISOString().replace("T", " ").slice(0, 19);
   const modelLabel = getModelLabel(model);
   const lines = [`# Pi Review — ${source}`, ``, `> ${date} · ${modelLabel}`, ``, `**Model:** ${modelLabel}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];
   if (globalComment) lines.push("## Comment", "", globalComment, "");

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -44,10 +44,11 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
     const filename = buildReviewFilename(source, now);
     if (saveRemote) {
       saveRemote(md, filename);
-      notify(`Review save requested → ${filename} (remote)`);
+      notify(`Review save requested → <remote-project-root>/${filename}`);
     } else {
-      await writeFile(path.join(cwd, filename), md, "utf-8");
-      notify(`Review saved → ${filename}`);
+      const filePath = path.join(cwd, filename);
+      await writeFile(filePath, md, "utf-8");
+      notify(`Review saved → ${filePath}`);
     }
   }
 

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -19,9 +19,12 @@ export interface UIHandlerOptions {
 }
 
 /**
- * Returns the injection message to send to the agent, or undefined if none.
- * Save is handled internally; the caller is responsible for sending the injection
- * message at the right time (after any agent-side save has completed).
+ * Orchestrates the interactive review UI flow and produces an agent injection message when the user requests sending.
+ *
+ * Starts a UI server for the given review, notifies the caller of the UI URL, waits for the user's action, and closes the UI.
+ * If the user chooses to save, the function will either write a timestamped markdown file into `cwd` or invoke `saveRemote` if provided.
+ *
+ * @returns A plain-text injection message for the agent if the user selected "send" or "save-and-send", `undefined` otherwise.
  */
 export async function handleUIReview(opts: UIHandlerOptions): Promise<string | undefined> {
   const { result, diff, conventions, source, ssh, cwd, notify, saveRemote } = opts;
@@ -55,11 +58,27 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
   return undefined;
 }
 
+/**
+ * Produce a compact label for a model using its provider and id.
+ *
+ * @param model - Optional model metadata with `provider`, `id`, and optional `name`
+ * @returns The label in the form `provider/id` if `model` is provided, otherwise `unknown`
+ */
 function getModelLabel(model: { provider: string; id: string; name?: string } | undefined): string {
   if (!model) return "unknown";
   return `${model.provider}/${model.id}`;
 }
 
+/**
+ * Create a markdown report summarizing review results and the decisions made for a given source.
+ *
+ * @param result - The review result containing a human summary and an array of comments referenced by decisions
+ * @param decisions - Decisions for each comment (accept, reject, discuss) that determine how each comment is presented
+ * @param source - The source identifier or path to include in the report title
+ * @param globalComment - Optional overall comment to include near the top of the report
+ * @param model - Optional model metadata; when provided the report header includes `provider/id` (or `"unknown"` if absent)
+ * @returns The complete review report as a markdown-formatted string
+ */
 function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string, model?: { provider: string; id: string; name?: string }): string {
   const date = new Date().toISOString().replace("T", " ").slice(0, 19);
   const modelLabel = getModelLabel(model);

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -15,7 +15,7 @@ export interface UIHandlerOptions {
   /** When set, save is delegated to the remote (SSH) instead of written locally. */
   saveRemote?: (markdown: string) => void;
   /** Current model info for review output. */
-  model?: { providerId: string; modelId: string };
+  model?: { provider: string; id: string; name?: string };
 }
 
 /**
@@ -55,12 +55,12 @@ export async function handleUIReview(opts: UIHandlerOptions): Promise<string | u
   return undefined;
 }
 
-function getModelLabel(model: { providerId: string; modelId: string } | undefined): string {
+function getModelLabel(model: { provider: string; id: string; name?: string } | undefined): string {
   if (!model) return "unknown";
-  return `${model.providerId}/${model.modelId}`;
+  return `${model.provider}/${model.id}`;
 }
 
-function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string, model?: { providerId: string; modelId: string }): string {
+function buildDecisionsMarkdown(result: ReviewResult, decisions: CommentDecision[], source: string, globalComment?: string, model?: { provider: string; id: string; name?: string }): string {
   const date = new Date().toISOString().replace("T", " ").slice(0, 19);
   const modelLabel = getModelLabel(model);
   const lines = [`# Pi Review — ${source}`, ``, `> ${date} · ${modelLabel}`, ``, `**Model:** ${modelLabel}`, ``, `---`, ``, `## Summary`, ``, result.summary, ``];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-reviewer",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-reviewer",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.55.1",
         "highlight.js": "^11.11.1"
@@ -791,7 +791,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3227,7 +3226,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3595,7 +3593,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4958,7 +4955,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5089,7 +5085,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5248,7 +5243,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5638,7 +5632,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5731,7 +5724,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -164,6 +164,20 @@ export function formatForTerminal(result: ReviewResult): string {
   return lines.join("\n");
 }
 
+/**
+ * Send a parsed review to the configured output target.
+ *
+ * Sends formatted review content (derived from `options.content`) to one of:
+ * - the terminal,
+ * - a GitHub PR (inline review or issue comment), or
+ * - a timestamped markdown file on disk.
+ *
+ * @param options - Configuration that specifies the review content, destination (`target`), optional minimum severity filter, and any GitHub or file settings required for the selected target.
+ * @throws Error - If `target` is `"comment"` and `githubToken` is not provided.
+ * @throws Error - If `target` is `"comment"` and `prNumber` is not a number.
+ * @throws Error - If `target` is `"comment"` and `repo` (owner/repo) is not provided.
+ * @throws Error - If posting the fallback GitHub issue comment fails (includes HTTP status and response body when available).
+ */
 export async function sendOutput(options: OutputOptions): Promise<void> {
   const result = parseAgentResponse(options.content, options.minSeverity);
 

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -241,7 +241,8 @@ export async function sendOutput(options: OutputOptions): Promise<void> {
   }
 
   const cwd = options.cwd ?? process.cwd();
-  const filePath = path.join(cwd, "pi-review.md");
+  const ts = new Date().toISOString().replace(/[T:]/g, "-").slice(0, 19);
+  const filePath = path.join(cwd, `pi-review-${ts}.md`);
   await writeFile(filePath, formatForTerminal(result), "utf-8");
   console.log(`[pi-reviewer] review saved to ${filePath}`);
 }

--- a/src/core/prompt-builder.ts
+++ b/src/core/prompt-builder.ts
@@ -75,8 +75,15 @@ export function buildJSONSystemPrompt(
 }
 
 /**
- * Markdown system prompt — used by SSH-only mode.
- * Agent writes a human-readable markdown review and saves it to a timestamped pi-review file.
+ * Constructs a Markdown-formatted system prompt for SSH-only code review agents.
+ *
+ * The prompt instructs the agent to produce a human-readable Markdown review containing
+ * a summary section with bullet points for each issue and an inline comments section
+ * listing file, line, and comment for each finding. It also instructs the agent to
+ * save the final review to `pi-review.md` in the project root using the Write tool.
+ *
+ * @param minSeverity - The minimum severity tier to include in the review (defaults to "INFO")
+ * @returns The full system prompt as a single string
  */
 export function buildMarkdownSystemPrompt(minSeverity: MinSeverity = "INFO"): string {
   return [

--- a/src/core/prompt-builder.ts
+++ b/src/core/prompt-builder.ts
@@ -76,7 +76,7 @@ export function buildJSONSystemPrompt(
 
 /**
  * Markdown system prompt — used by SSH-only mode.
- * Agent writes a human-readable markdown review and saves it to pi-review.md.
+ * Agent writes a human-readable markdown review and saves it to a timestamped pi-review file.
  */
 export function buildMarkdownSystemPrompt(minSeverity: MinSeverity = "INFO"): string {
   return [

--- a/src/core/ui/server.ts
+++ b/src/core/ui/server.ts
@@ -62,7 +62,7 @@ export interface UIServerHandle {
 // triggers on browser crash or network drop. 45s = one missed ping + grace.
 const HEARTBEAT_MS = 45_000;
 
-export async function startUIServer(result: ReviewResult, diff: string, source?: string, ssh?: boolean): Promise<UIServerHandle> {
+export async function startUIServer(result: ReviewResult, diff: string, source?: string, ssh?: boolean, autoOpen = true): Promise<UIServerHandle> {
   const html = buildHTML(result, diff, source, ssh, readTheme(), readViewMode());
 
   let resolveAction!: (a: UIAction) => void;
@@ -138,7 +138,7 @@ export async function startUIServer(result: ReviewResult, diff: string, source?:
   const port = await listenOnRandomPort(server);
   const url = "http://localhost:" + port;
   resetHeartbeat();
-  openBrowser(url);
+  if (autoOpen) openBrowser(url);
 
   return {
     url,

--- a/tests/core/output.test.ts
+++ b/tests/core/output.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -340,7 +340,7 @@ describe("sendOutput", () => {
     ).rejects.toThrow("Failed to post GitHub comment: 403 Forbidden");
   });
 
-  it("writes formatted review to pi-review.md for file target", async () => {
+  it("writes formatted review to timestamped pi-review file for file target", async () => {
     const dir = await createTempDir();
 
     await sendOutput({
@@ -354,11 +354,15 @@ describe("sendOutput", () => {
       cwd: dir,
     });
 
-    const content = await readFile(path.join(dir, "pi-review.md"), "utf-8");
+    const files = await readdir(dir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^pi-review-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.md$/);
+
+    const content = await readFile(path.join(dir, files[0]), "utf-8");
     expect(content).toBe(
       "== Review Summary ==\nPlease address comments\n\n== Inline Comments ==\n🟡 src/a.ts:7 (RIGHT)\n🟡 Handle undefined"
     );
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("pi-review.md"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(files[0]));
   });
 
   it("filters comments by minSeverity when posting", async () => {

--- a/tests/core/ui/server.test.ts
+++ b/tests/core/ui/server.test.ts
@@ -2,7 +2,7 @@ import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReviewResult } from "../../../src/core/output.js";
 import { buildHTML } from "../../../src/core/ui/template.js";
-import { startUIServer, openBrowser, type UIAction } from "../../../src/core/ui/server.js";
+import { startUIServer, type UIAction } from "../../../src/core/ui/server.js";
 
 const RESULT: ReviewResult = {
   summary: "Looks good overall.",
@@ -82,17 +82,14 @@ function post(url: string, body: unknown): Promise<{ status: number }> {
 }
 
 describe("startUIServer", () => {
-  // Prevent actual browser from opening during tests
-  vi.spyOn({ openBrowser }, "openBrowser").mockImplementation(() => {});
-
   it("starts a server and returns a localhost URL", async () => {
-    const handle = await startUIServer(RESULT, DIFF);
+    const handle = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     expect(handle.url).toMatch(/^http:\/\/localhost:\d+$/);
     await handle.close();
   });
 
   it("serves the HTML page on GET /", async () => {
-    const handle = await startUIServer(RESULT, DIFF);
+    const handle = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     const { status, body } = await get(handle.url);
     expect(status).toBe(200);
     expect(body).toContain("Pi Review");
@@ -101,27 +98,27 @@ describe("startUIServer", () => {
   });
 
   it("responds on a port different from the previous instance", async () => {
-    const a = await startUIServer(RESULT, DIFF);
-    const b = await startUIServer(RESULT, DIFF);
+    const a = await startUIServer(RESULT, DIFF, undefined, undefined, false);
+    const b = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     expect(a.url).not.toBe(b.url);
     await Promise.all([a.close(), b.close()]);
   });
 
   it("close() shuts the server down so subsequent requests fail", async () => {
-    const handle = await startUIServer(RESULT, DIFF);
+    const handle = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     await handle.close();
     await expect(get(handle.url)).rejects.toThrow();
   });
 
   it("GET /ping returns 204", async () => {
-    const handle = await startUIServer(RESULT, DIFF);
+    const handle = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     const { status } = await get(handle.url + "/ping");
     expect(status).toBe(204);
     await handle.close();
   });
 
   it("POST /action resolves waitForAction with the payload", async () => {
-    const handle = await startUIServer(RESULT, DIFF);
+    const handle = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     const payload: UIAction = {
       type: "save",
       decisions: [{ index: 0, decision: "accept" }, { index: 1, decision: "reject" }],
@@ -134,7 +131,7 @@ describe("startUIServer", () => {
   });
 
   it("POST /action with invalid JSON returns 400", async () => {
-    const handle = await startUIServer(RESULT, DIFF);
+    const handle = await startUIServer(RESULT, DIFF, undefined, undefined, false);
     const { status } = await new Promise<{ status: number }>((resolve, reject) => {
       const req = http.request(handle.url + "/action", { method: "POST" }, (res) => {
         res.resume();


### PR DESCRIPTION
## What

Two changes to the review output:

### 1. Timestamped filenames (no more overwrite)

Before:
```
pi-review.md  ← always overwritten, reviews lost on re-run
```

After:
```
pi-review-2026-04-22-14-30-00-PR-39.md
pi-review-2026-04-22-15-00-00-feat-branch-vs-main.md
```

The filename includes:
- **ISO timestamp** — sortable, unambiguous, no timezone confusion
- **Source slug** — derived from `source` (e.g. `PR-39`, `feat-destaque-vs-origin-main`, `HEAD-1`)

This means:
- Re-running `/review` never destroys previous results
- Multiple PRs/branches reviewed over time coexist naturally
- `pi-review*.md` in `.gitignore` covers all variants

### 2. Model attribution in review document

Each review now records which model executed it:

```markdown
# Pi Review — PR #39

> 2026-04-22 14:30:00 · ollama/qwen3-coder

**Model:** ollama/qwen3-coder

---

== Review Summary ==
...
```

Why this matters:
- **Accountability** — different models produce different quality reviews; you need to know who reviewed
- **Reproducibility** — when comparing review quality across models, the model info is embedded in the artifact
- **Model-agnostic by design** — works with any provider (ollama/qwen, anthropic/claude-sonnet, openai/gpt-4o, etc.)

Model info comes from `ctx.model` (`{ provider, id, name? }`) — available in the extension command context with no extra API calls.

## Files changed

| File | Change |
|------|--------|
| `extensions/pi-reviewer/index.ts` | `buildReviewFilename()` + `getModelLabel()` |
| `extensions/pi-reviewer/ui-handler.ts` | Timestamped filename in UI save + model in decisions markdown |
| `extensions/pi-reviewer/run-ssh.ts` | Updated notify message |
| `src/core/output.ts` | Timestamped filename in `sendOutput` file target |
| `src/core/prompt-builder.ts` | Updated JSDoc comment |

## Backwards compatibility

- No breaking changes to CLI flags, prompts, or CI action
- Existing `pi-review.md` reference in SSH prompt is kept (agent still writes to `pi-review.md` — the filename change only applies to the extension-controlled writes)
- Users who relied on `pi-review.md` being a fixed path should update to `pi-review*.md` glob

## Testing

- [x] `npm run build` passes
- [x] `/review --pr 39` produces `pi-review-YYYY-MM-DD-HH-MM-SS-PR-39.md` with correct model label
- [x] `/review` on local branch produces similar timestamped file
- [ ] `/review --ui` save action produces timestamped file + model attribution
- [ ] `/review --ssh` produces correct notify message
- [ ] CI action (sendOutput file target) produces timestamped file

## Open questions

- Should the SSH prompt (`buildMarkdownSystemPrompt`) instruct the agent to save to a timestamped filename too? Currently it still says `pi-review.md` because the agent on the remote cannot easily know the timestamp format. Open to suggestions.