### PR TITLE
refactor(context): unified ContextFile[] type, monorepo walk-up, SSH …

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Progress is shown in the pi TUI as the review runs — diff fetch, context load,
 
 ### SSH mode (`--ssh`)
 
-For reviewing code on a remote machine. Instead of spawning a subprocess, SSH mode runs directly inside the current pi agent session — which already has SSH bash tool access to the remote. The agent fetches the diff and conventions on the remote, runs the review, and saves `pi-review.md` there. No local git access needed. Requires an SSH extension (e.g. [ssh.ts](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/examples/extensions/ssh.ts)) to be active.
+For reviewing code on a remote machine. Instead of spawning a subprocess, SSH mode runs directly inside the current pi agent session — which already has SSH bash tool access to the remote. The agent fetches the diff on the remote, runs the review, and saves `pi-review.md` there. No local git access needed. Requires an SSH extension (e.g. [ssh.ts](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/examples/extensions/ssh.ts)) to be active.
 
 ```
 /review --ssh
@@ -38,7 +38,7 @@ For reviewing code on a remote machine. Instead of spawning a subprocess, SSH mo
 /review --ssh --branch dev
 ```
 
-The agent reads `AGENTS.md` / `CLAUDE.md` and `REVIEW.md` from the remote project root, runs the review, and saves `pi-review.md` directly on the remote.
+pi-reviewer reads `AGENTS.md` / `CLAUDE.md` and `REVIEW.md` from the remote project root over SSH before starting the agent, then injects them into the system prompt. The agent fetches the diff, runs the review, and saves `pi-review.md` directly on the remote.
 
 > **Note:** `--model` and `--thinking` have no effect in SSH mode. Because the review runs inside the existing pi session (not a subprocess), the model and thinking level are fixed to whatever the parent session is using.
 
@@ -192,7 +192,7 @@ Then inside the pi TUI:
 | `--min-severity <level>` | Only report issues at this level and above: `info`, `warn`, or `critical` (default: `info`) | `--min-severity warn` |
 | `--model <id>` | Model to use for this review in `provider/id` format, overrides config default. **Local mode only** — ignored in `--ssh`. | `--model openai/gpt-4o` |
 | `--thinking <level>` | Agent thinking budget: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. **Local mode only** — ignored in `--ssh`. | `--thinking low` |
-| `--dir <path>` | Run the review in a specific directory (e.g. a sub-project in a monorepo). The path must be a git repository. | `--dir packages/api` |
+| `--dir <path>` | Run the review in a specific directory (e.g. a sub-project in a monorepo). The path must be a git repository. Context files (`AGENTS.md`, `REVIEW.md`) are loaded from the sub-project and all ancestor directories up to the outer project root. | `--dir packages/api` |
 | `--verbose` | Print full agent output to the console | |
 | `--dry-run` | Print the diff and prompt without calling the agent | |
 
@@ -260,8 +260,9 @@ Create `AGENTS.md` or `CLAUDE.md` at the root of your project to give the review
 
 - `AGENTS.md` is checked first; `CLAUDE.md` is used as a fallback if `AGENTS.md` is not found.
 - Filenames are matched case-insensitively (`agents.md`, `Agents.md`, and `AGENTS.md` all work).
+- Files can also live in `.pi/`, `.claude/`, or `.agents/` subdirectories — e.g. `.pi/AGENTS.md`.
 - `REVIEW.md` is always loaded alongside `AGENTS.md`/`CLAUDE.md` when present — use it for review-specific rules that don't belong in your general conventions.
-- Markdown links to other `.md` files (e.g. `[api conventions](./docs/api.md)`) are automatically inlined so the agent sees the full context.
+- **Monorepo support:** pi-reviewer walks up from the working directory to the git root and collects `AGENTS.md`/`REVIEW.md` at every ancestor level (root first, package last). When using `--dir`, the walk-up extends to the outer project root so shared root conventions are always included alongside package-specific ones.
 
 **`AGENTS.md`** — general project conventions:
 ```markdown
@@ -271,8 +272,6 @@ Create `AGENTS.md` or `CLAUDE.md` at the root of your project to give the review
 - Prefix async data fetchers with `fetch` (e.g. `fetchUser`, `fetchOrders`)
 - Prefix boolean functions with `is`, `has`, or `can`
 - Prefix mutations with a verb: `update`, `delete`, `create`, `reset`
-
-[API conventions](./docs/api-conventions.md)
 ```
 
 **`REVIEW.md`** — review-only rules (what to flag, what to skip):

--- a/dist/extensions/pi-reviewer/index.js
+++ b/dist/extensions/pi-reviewer/index.js
@@ -6,6 +6,8 @@ import { filterDiff } from "../../src/core/diff-filter.js";
 import { formatForTerminal } from "../../src/core/output.js";
 import { buildJSONSystemPrompt, buildMarkdownSystemPrompt, buildSSHUserPrompt, buildUserPrompt } from "../../src/core/prompt-builder.js";
 import { readVerbose, readMinSeverity, readModel, readThinking, readDefaultBranch } from "../../src/core/ui/server/index.js";
+import { loadContextSSH } from "../../src/core/context.js";
+import { readSshFlag, resolveSshState } from "../../src/core/ssh.js";
 import { parseArgs } from "./args.js";
 import { setReviewFooter } from "./footer.js";
 import { runLocalReview } from "./run-local.js";
@@ -62,7 +64,7 @@ export default function (pi) {
                     }
                     else {
                         const { diff, source, skippedFiles } = await resolveDiff({ cwd: ctx.cwd, diff: parsed.diff, branch: parsed.branch ?? readDefaultBranch(), pr: parsed.pr, dir: parsed.dir });
-                        const context = await loadContext({ cwd: ctx.cwd });
+                        const context = await loadContext({ cwd: parsed.dir ? path.resolve(ctx.cwd, parsed.dir) : ctx.cwd, gitRoot: parsed.dir ? ctx.cwd : undefined });
                         notify(`Diff source: ${source}`);
                         notify(`System prompt:\n\n${buildJSONSystemPrompt(context, minSeverity)}`);
                         notify(`User prompt:\n\n${buildUserPrompt(diff, skippedFiles)}`);
@@ -74,15 +76,27 @@ export default function (pi) {
                     const diffCommand = buildSSHDiffCommand(parsed);
                     const source = buildSSHSource(parsed, ctx.cwd);
                     const userPrompt = buildSSHUserPrompt(diffCommand);
+                    notify("Loading context…");
+                    const sshFlag = readSshFlag();
+                    const sshContext = sshFlag
+                        ? await resolveSshState(sshFlag).then(s => {
+                            const remoteCwd = parsed.dir ? path.posix.join(s.remoteCwd, parsed.dir) : s.remoteCwd;
+                            const gitRoot = parsed.dir ? s.remoteCwd : undefined;
+                            return loadContextSSH(s.remote, remoteCwd, gitRoot);
+                        }).catch(() => ({ conventions: [], reviewRules: [] }))
+                        : { conventions: [], reviewRules: [] };
+                    const sshLoadedPaths = [...sshContext.conventions, ...sshContext.reviewRules].map(f => f.path);
+                    if (sshLoadedPaths.length > 0)
+                        notify(`Context: ${sshLoadedPaths.join(", ")}`);
                     if (!parsed.ui) {
                         // SSH-only: agent fetches diff, reviews, saves markdown
-                        const systemPrompt = buildMarkdownSystemPrompt(minSeverity);
+                        const systemPrompt = buildMarkdownSystemPrompt(minSeverity, sshContext);
                         stopLoader = setReviewFooter(ctx, source, { model: currentModelId, thinking });
                         runSSHReview({ systemPrompt, userPrompt, pi, stopLoader, notify });
                         return;
                     }
                     // SSH+UI: agent fetches diff, reviews; diff is captured from bash tool result
-                    const systemPrompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" }, minSeverity);
+                    const systemPrompt = buildJSONSystemPrompt(sshContext, minSeverity);
                     stopLoader = setReviewFooter(ctx, source, { model: currentModelId, thinking });
                     const result = await runSSHReviewAndWait({ systemPrompt, userPrompt, pi, minSeverity, stopLoader, notify });
                     if (!result.diff)
@@ -90,9 +104,10 @@ export default function (pi) {
                     const { diff, warning } = filterDiff(result.diff ?? "");
                     if (warning)
                         notify(warning, "warning");
+                    const conventions = [...sshContext.conventions, ...sshContext.reviewRules].map(f => f.content).join("\n\n");
                     let sshSaveTriggered = false;
                     const injectionMsg = await handleUIReview({
-                        result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify,
+                        result, diff, conventions, source, ssh: true, cwd: ctx.cwd, notify,
                         currentModel: currentModelId, currentThinking: thinking, defaultModel, availableModels, defaultThinking: readThinking(),
                         saveRemote: (md) => {
                             sshSaveTriggered = true;
@@ -122,10 +137,11 @@ export default function (pi) {
                 if (warning)
                     notify(warning, "warning");
                 notify("Loading context…");
-                const context = await loadContext({ cwd: ctx.cwd });
-                if ((context.loadedFiles?.length ?? 0) > 0)
-                    notify(`Context: ${context.loadedFiles?.join(", ")}`);
-                const conventions = [context.conventions, context.reviewRules].filter(Boolean).join("\n\n");
+                const context = await loadContext({ cwd: parsed.dir ? path.resolve(ctx.cwd, parsed.dir) : ctx.cwd, gitRoot: parsed.dir ? ctx.cwd : undefined });
+                const loadedPaths = [...context.conventions, ...context.reviewRules].map(f => f.path);
+                if (loadedPaths.length > 0)
+                    notify(`Context: ${loadedPaths.join(", ")}`);
+                const conventions = [...context.conventions, ...context.reviewRules].map(f => f.content).join("\n\n");
                 const systemPrompt = buildJSONSystemPrompt(context, minSeverity);
                 const userPrompt = buildUserPrompt(diff, skippedFiles);
                 stopLoader = setReviewFooter(ctx, source, { model: currentModelId, thinking });

--- a/dist/src/ci/review.js
+++ b/dist/src/ci/review.js
@@ -20,8 +20,9 @@ export async function review(options) {
     if (warning)
         console.warn(`[pi-reviewer] ${warning}`);
     const context = await loadContext({ cwd });
-    if ((context.loadedFiles?.length ?? 0) > 0) {
-        console.log(`[pi-reviewer] context loaded: ${context.loadedFiles?.join(", ")}`);
+    const loadedPaths = [...context.conventions, ...context.reviewRules].map(f => f.path);
+    if (loadedPaths.length > 0) {
+        console.log(`[pi-reviewer] context loaded: ${loadedPaths.join(", ")}`);
     }
     else {
         console.log("[pi-reviewer] context: no conventions found (AGENTS.md / CLAUDE.md / REVIEW.md)");

--- a/dist/src/core/context.js
+++ b/dist/src/core/context.js
@@ -1,76 +1,80 @@
-import { readFile, readdir } from "node:fs/promises";
-import path from "node:path";
-async function tryReadFile(filePath) {
+import { execSync } from "node:child_process";
+import { localFs, sshExec, sshFs } from "./ssh.js";
+const CONFIG_DIRS = [".pi", ".claude", ".agents"];
+function findGitRoot(cwd) {
     try {
-        return await readFile(filePath, "utf-8");
-    }
-    catch (error) {
-        if (error.code === "ENOENT")
-            return null;
-        throw error;
-    }
-}
-async function findFileCaseInsensitive(dir, name) {
-    try {
-        const entries = await readdir(dir);
-        const match = entries.find((e) => e.toLowerCase() === name.toLowerCase());
-        return match ? path.join(dir, match) : null;
+        return execSync("git rev-parse --show-toplevel", {
+            cwd,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
     }
     catch {
         return null;
     }
 }
-async function resolveLinks(content, baseDir, visited, loaded) {
-    const linkPattern = /\[([^\]]*)\]\(([^)]+\.md)\)/g;
-    const replacements = [];
-    for (const match of content.matchAll(linkPattern)) {
-        const [full, , href] = match;
-        if (href.startsWith("http"))
+async function readContextFile(fs, dir, filename) {
+    for (const candidate of [dir, ...CONFIG_DIRS.map(d => fs.join(dir, d))]) {
+        const entries = await fs.list(candidate);
+        const match = entries.find(e => e.toLowerCase() === filename.toLowerCase());
+        if (!match)
             continue;
-        const absPath = path.resolve(baseDir, href);
-        if (visited.has(absPath))
-            continue;
-        const linked = await tryReadFile(absPath);
-        if (linked === null)
-            continue;
-        visited.add(absPath);
-        loaded.push(absPath);
-        const resolved = await resolveLinks(linked, path.dirname(absPath), visited, loaded);
-        replacements.push({ match: full, replacement: resolved.trim() });
+        const filePath = fs.join(candidate, match);
+        const content = await fs.read(filePath);
+        if (content !== null)
+            return { path: filePath, content };
     }
-    let result = content;
-    for (const { match, replacement } of replacements) {
-        result = result.replace(match, replacement);
+    return null;
+}
+/**
+ * Walks from gitRoot down to cwd, collecting one matching file per directory level.
+ * filenames: tried in priority order at each level (first match wins).
+ * Returns files in root → cwd order.
+ */
+export async function walkUpContextFiles(fs, cwd, filenames, gitRoot) {
+    const dirs = [];
+    let current = cwd;
+    while (true) {
+        dirs.unshift(current);
+        if (current === gitRoot)
+            break;
+        const parent = fs.dirname(current);
+        if (parent === current)
+            break;
+        current = parent;
+    }
+    const result = [];
+    const visited = new Set();
+    for (const dir of dirs) {
+        for (const filename of filenames) {
+            const file = await readContextFile(fs, dir, filename);
+            if (file === null || visited.has(file.path))
+                continue;
+            visited.add(file.path);
+            result.push({ path: fs.relative(cwd, file.path), content: file.content });
+            break; // one file per directory level
+        }
     }
     return result;
 }
 export async function loadContext(options = {}) {
     const cwd = options.cwd ?? process.cwd();
-    const loaded = [];
-    const visited = new Set();
-    let conventions = "";
-    for (const filename of ["AGENTS.md", "CLAUDE.md"]) {
-        const absPath = await findFileCaseInsensitive(cwd, filename);
-        if (absPath === null)
-            continue;
-        const content = await tryReadFile(absPath);
-        if (content !== null) {
-            visited.add(absPath);
-            loaded.push(absPath);
-            conventions = await resolveLinks(content, cwd, visited, loaded);
-            break;
-        }
-    }
-    const reviewAbsPath = await findFileCaseInsensitive(cwd, "REVIEW.md");
-    let reviewRules = "";
-    if (reviewAbsPath !== null) {
-        const reviewRaw = await tryReadFile(reviewAbsPath);
-        if (reviewRaw !== null) {
-            visited.add(reviewAbsPath);
-            loaded.push(reviewAbsPath);
-            reviewRules = await resolveLinks(reviewRaw, cwd, visited, loaded);
-        }
-    }
-    const loadedFiles = loaded.map((f) => path.relative(cwd, f));
-    return { conventions, reviewRules, loadedFiles };
+    const gitRoot = options.gitRoot ?? findGitRoot(cwd) ?? cwd;
+    const fs = localFs();
+    const [conventions, reviewRules] = await Promise.all([
+        walkUpContextFiles(fs, cwd, ["AGENTS.md", "CLAUDE.md"], gitRoot),
+        walkUpContextFiles(fs, cwd, ["REVIEW.md"], gitRoot),
+    ]);
+    return { conventions, reviewRules };
+}
+export async function loadContextSSH(remote, remoteCwd, gitRoot) {
+    const fs = sshFs(remote);
+    const resolvedGitRoot = gitRoot ?? await sshExec(remote, `git -C ${JSON.stringify(remoteCwd)} rev-parse --show-toplevel`)
+        .then(out => out.trim())
+        .catch(() => remoteCwd);
+    const [conventions, reviewRules] = await Promise.all([
+        walkUpContextFiles(fs, remoteCwd, ["AGENTS.md", "CLAUDE.md"], resolvedGitRoot),
+        walkUpContextFiles(fs, remoteCwd, ["REVIEW.md"], resolvedGitRoot),
+    ]);
+    return { conventions, reviewRules };
 }

--- a/dist/src/core/prompt-builder.js
+++ b/dist/src/core/prompt-builder.js
@@ -3,6 +3,9 @@ const SEVERITY_RULE = {
     WARN: "- Only report CRITICAL and WARN issues — skip INFO",
     CRITICAL: "- Only report CRITICAL issues — skip WARN and INFO",
 };
+function mergeContent(files) {
+    return files.map(f => f.content).join("\n\n");
+}
 // ── Shared base ───────────────────────────────────────────────────────────────
 function buildSharedBase(minSeverity) {
     const severityRule = SEVERITY_RULE[minSeverity];
@@ -52,21 +55,21 @@ export function buildJSONSystemPrompt(context, minSeverity = "INFO") {
         '- severity: "CRITICAL" | "WARN" | "INFO"',
         "- body: inline comment text, may use Markdown",
     ].join("\n");
-    const conventions = typeof context === "string" ? context : context.conventions;
-    const reviewRules = typeof context === "string" ? "" : context.reviewRules;
+    const conventionsStr = typeof context === "string" ? context : mergeContent(context.conventions);
+    const reviewRulesStr = typeof context === "string" ? "" : mergeContent(context.reviewRules);
     const sections = [base];
-    if (conventions.trim())
-        sections.push(`<conventions>\n${conventions}\n</conventions>`);
-    if (reviewRules.trim())
-        sections.push(`<review_rules>\n${reviewRules}\n</review_rules>`);
+    if (conventionsStr.trim())
+        sections.push(`<conventions>\n${conventionsStr}\n</conventions>`);
+    if (reviewRulesStr.trim())
+        sections.push(`<review_rules>\n${reviewRulesStr}\n</review_rules>`);
     return sections.join("\n\n");
 }
 /**
  * Markdown system prompt — used by SSH-only mode.
  * Agent writes a human-readable markdown review and saves it to pi-review.md.
  */
-export function buildMarkdownSystemPrompt(minSeverity = "INFO") {
-    return [
+export function buildMarkdownSystemPrompt(minSeverity = "INFO", context) {
+    const base = [
         ...buildSharedBase(minSeverity),
         "",
         "Write your review as Markdown with:",
@@ -75,6 +78,16 @@ export function buildMarkdownSystemPrompt(minSeverity = "INFO") {
         "",
         "After writing your review, save it to pi-review.md in the project root using the Write tool.",
     ].join("\n");
+    if (!context)
+        return base;
+    const conventionsStr = typeof context === "string" ? context : mergeContent(context.conventions);
+    const reviewRulesStr = typeof context === "string" ? "" : mergeContent(context.reviewRules);
+    const sections = [base];
+    if (conventionsStr.trim())
+        sections.push(`<conventions>\n${conventionsStr}\n</conventions>`);
+    if (reviewRulesStr.trim())
+        sections.push(`<review_rules>\n${reviewRulesStr}\n</review_rules>`);
+    return sections.join("\n\n");
 }
 // ── User prompts ──────────────────────────────────────────────────────────────
 /** Local mode — diff only, conventions already in system prompt. */
@@ -98,9 +111,6 @@ export function buildSSHUserPrompt(diffCommand) {
         `    <command>${diffCommand}</command>`,
         "  </step>",
         "  <step index=\"2\">",
-        "    Read AGENTS.md or CLAUDE.md from the project root if either exists. Scan for markdown links matching [text](./path.md) and read each linked .md file recursively (at any depth). Also read REVIEW.md from the project root if it exists (same recursive rule). These files contain project conventions and review-specific rules.",
-        "  </step>",
-        "  <step index=\"3\">",
         "    Review the diff according to the system prompt instructions.",
         "  </step>",
         "</request>",

--- a/dist/src/core/ssh.js
+++ b/dist/src/core/ssh.js
@@ -1,0 +1,89 @@
+import { execFile } from "node:child_process";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { dirname as posixDirname, join as posixJoin, relative as posixRelative } from "node:path/posix";
+export function localFs() {
+    return {
+        async read(p) {
+            try {
+                return await readFile(p, "utf-8");
+            }
+            catch {
+                return null;
+            }
+        },
+        async list(dir) {
+            try {
+                return await readdir(dir);
+            }
+            catch {
+                return [];
+            }
+        },
+        join,
+        dirname,
+        relative,
+    };
+}
+export function sshExec(remote, command) {
+    return new Promise((resolve, reject) => {
+        execFile("ssh", [remote, command], { encoding: "utf8" }, (err, stdout) => {
+            if (err)
+                reject(err);
+            else
+                resolve(stdout);
+        });
+    });
+}
+export function sshFs(remote) {
+    return {
+        async read(p) {
+            try {
+                return await sshExec(remote, `cat ${JSON.stringify(p)}`);
+            }
+            catch {
+                return null;
+            }
+        },
+        async list(dir) {
+            try {
+                const out = await sshExec(remote, `ls -1 ${JSON.stringify(dir)}`);
+                return out.split("\n").map(l => l.trim()).filter(Boolean);
+            }
+            catch {
+                return [];
+            }
+        },
+        join: posixJoin,
+        dirname: posixDirname,
+        relative: posixRelative,
+    };
+}
+/**
+ * Reads --ssh user@host (or --ssh=user@host) from process.argv.
+ */
+export function readSshFlag() {
+    const args = process.argv;
+    for (let i = 1; i < args.length; i++) {
+        if (args[i] === "--ssh" && i + 1 < args.length)
+            return args[i + 1];
+        if (args[i].startsWith("--ssh="))
+            return args[i].slice(6);
+    }
+    return undefined;
+}
+/**
+ * Resolves SSH state from the --ssh flag value.
+ * Supports user@host:/path and user@host (cwd resolved via pwd).
+ */
+export async function resolveSshState(flag) {
+    const colonIdx = flag.indexOf(":");
+    if (colonIdx !== -1) {
+        const remote = flag.slice(0, colonIdx);
+        const rawCwd = flag.slice(colonIdx + 1);
+        const remoteCwd = (await sshExec(remote, `cd ${rawCwd} && pwd`)).trim();
+        return { remote, remoteCwd };
+    }
+    const remoteCwd = (await sshExec(flag, "pwd")).trim();
+    return { remote: flag, remoteCwd };
+}

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -8,6 +8,8 @@ import { filterDiff } from "../../src/core/diff-filter.js";
 import { formatForTerminal } from "../../src/core/output.js";
 import { buildJSONSystemPrompt, buildMarkdownSystemPrompt, buildSSHUserPrompt, buildUserPrompt } from "../../src/core/prompt-builder.js";
 import { readVerbose, readMinSeverity, readModel, readThinking, readDefaultBranch } from "../../src/core/ui/server/index.js";
+import { loadContextSSH } from "../../src/core/context.js";
+import { readSshFlag, resolveSshState } from "../../src/core/ssh.js";
 import type { ReviewCommandArgs } from "./args.js";
 import { parseArgs } from "./args.js";
 import { setReviewFooter } from "./footer.js";
@@ -65,7 +67,7 @@ export default function (pi: ExtensionAPI): void {
             notify(`User prompt:\n\n${buildSSHUserPrompt(buildSSHDiffCommand(parsed))}`);
           } else {
             const { diff, source, skippedFiles } = await resolveDiff({ cwd: ctx.cwd, diff: parsed.diff, branch: parsed.branch ?? readDefaultBranch(), pr: parsed.pr, dir: parsed.dir });
-            const context = await loadContext({ cwd: ctx.cwd });
+            const context = await loadContext({ cwd: parsed.dir ? path.resolve(ctx.cwd, parsed.dir) : ctx.cwd, gitRoot: parsed.dir ? ctx.cwd : undefined });
             notify(`Diff source: ${source}`);
             notify(`System prompt:\n\n${buildJSONSystemPrompt(context, minSeverity)}`);
             notify(`User prompt:\n\n${buildUserPrompt(diff, skippedFiles)}`);
@@ -79,24 +81,37 @@ export default function (pi: ExtensionAPI): void {
           const source = buildSSHSource(parsed, ctx.cwd);
           const userPrompt = buildSSHUserPrompt(diffCommand);
 
+          notify("Loading context…");
+          const sshFlag = readSshFlag();
+          const sshContext = sshFlag
+            ? await resolveSshState(sshFlag).then(s => {
+                const remoteCwd = parsed.dir ? path.posix.join(s.remoteCwd, parsed.dir) : s.remoteCwd;
+                const gitRoot = parsed.dir ? s.remoteCwd : undefined;
+                return loadContextSSH(s.remote, remoteCwd, gitRoot);
+              }).catch(() => ({ conventions: [], reviewRules: [] }))
+            : { conventions: [], reviewRules: [] };
+          const sshLoadedPaths = [...sshContext.conventions, ...sshContext.reviewRules].map(f => f.path);
+          if (sshLoadedPaths.length > 0) notify(`Context: ${sshLoadedPaths.join(", ")}`);
+
           if (!parsed.ui) {
             // SSH-only: agent fetches diff, reviews, saves markdown
-            const systemPrompt = buildMarkdownSystemPrompt(minSeverity);
+            const systemPrompt = buildMarkdownSystemPrompt(minSeverity, sshContext);
             stopLoader = setReviewFooter(ctx, source, { model: currentModelId, thinking });
             runSSHReview({ systemPrompt, userPrompt, pi, stopLoader, notify });
             return;
           }
 
           // SSH+UI: agent fetches diff, reviews; diff is captured from bash tool result
-          const systemPrompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" }, minSeverity);
+          const systemPrompt = buildJSONSystemPrompt(sshContext, minSeverity);
           stopLoader = setReviewFooter(ctx, source, { model: currentModelId, thinking });
           const result = await runSSHReviewAndWait({ systemPrompt, userPrompt, pi, minSeverity, stopLoader, notify });
           if (!result.diff) notify("Diff not captured — UI diff view will be empty", "warning");
           const { diff, warning } = filterDiff(result.diff ?? "");
           if (warning) notify(warning, "warning");
+          const conventions = [...sshContext.conventions, ...sshContext.reviewRules].map(f => f.content).join("\n\n");
           let sshSaveTriggered = false;
           const injectionMsg = await handleUIReview({
-            result, diff, conventions: "", source, ssh: true, cwd: ctx.cwd, notify,
+            result, diff, conventions, source, ssh: true, cwd: ctx.cwd, notify,
             currentModel: currentModelId, currentThinking: thinking, defaultModel, availableModels, defaultThinking: readThinking(),
             saveRemote: (md) => {
               sshSaveTriggered = true;
@@ -124,9 +139,10 @@ export default function (pi: ExtensionAPI): void {
         const { diff, source, warning, skippedFiles } = await resolveDiff({ cwd: ctx.cwd, diff: parsed.diff, branch: parsed.branch ?? readDefaultBranch(), pr: parsed.pr, dir: parsed.dir });
         if (warning) notify(warning, "warning");
         notify("Loading context…");
-        const context = await loadContext({ cwd: ctx.cwd });
-        if ((context.loadedFiles?.length ?? 0) > 0) notify(`Context: ${context.loadedFiles?.join(", ")}`);
-        const conventions = [context.conventions, context.reviewRules].filter(Boolean).join("\n\n");
+        const context = await loadContext({ cwd: parsed.dir ? path.resolve(ctx.cwd, parsed.dir) : ctx.cwd, gitRoot: parsed.dir ? ctx.cwd : undefined });
+        const loadedPaths = [...context.conventions, ...context.reviewRules].map(f => f.path);
+        if (loadedPaths.length > 0) notify(`Context: ${loadedPaths.join(", ")}`);
+        const conventions = [...context.conventions, ...context.reviewRules].map(f => f.content).join("\n\n");
         const systemPrompt = buildJSONSystemPrompt(context, minSeverity);
         const userPrompt = buildUserPrompt(diff, skippedFiles);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-reviewer",
-  "version": "0.4",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/src/ci/review.ts
+++ b/src/ci/review.ts
@@ -39,8 +39,9 @@ export async function review(options: ReviewOptions): Promise<void> {
   if (warning) console.warn(`[pi-reviewer] ${warning}`);
 
   const context = await loadContext({ cwd });
-  if ((context.loadedFiles?.length ?? 0) > 0) {
-    console.log(`[pi-reviewer] context loaded: ${context.loadedFiles?.join(", ")}`);
+  const loadedPaths = [...context.conventions, ...context.reviewRules].map(f => f.path);
+  if (loadedPaths.length > 0) {
+    console.log(`[pi-reviewer] context loaded: ${loadedPaths.join(", ")}`);
   } else {
     console.log("[pi-reviewer] context: no conventions found (AGENTS.md / CLAUDE.md / REVIEW.md)");
   }

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,97 +1,111 @@
-import { readFile, readdir } from "node:fs/promises";
-import path from "node:path";
+import { execSync } from "node:child_process";
+import { localFs, sshExec, sshFs, type FsOps } from "./ssh.js";
+
+const CONFIG_DIRS = [".pi", ".claude", ".agents"];
 
 export interface ContextOptions {
   cwd?: string;
+  gitRoot?: string; // override auto-detected git root (e.g. outer monorepo root when --dir is a nested repo)
+}
+
+export interface ContextFile {
+  path: string;    // relative to cwd (local) or relative to remoteCwd (SSH)
+  content: string;
 }
 
 export interface ContextResult {
-  conventions: string; // from AGENTS.md or CLAUDE.md
-  reviewRules: string; // from REVIEW.md
-  loadedFiles?: string[]; // all files loaded (root + inlined links), relative to cwd
+  conventions: ContextFile[]; // AGENTS.md / CLAUDE.md, root → cwd order
+  reviewRules: ContextFile[]; // REVIEW.md, root → cwd order
 }
 
-async function tryReadFile(filePath: string): Promise<string | null> {
+function findGitRoot(cwd: string): string | null {
   try {
-    return await readFile(filePath, "utf-8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
-  }
-}
-
-async function findFileCaseInsensitive(dir: string, name: string): Promise<string | null> {
-  try {
-    const entries = await readdir(dir);
-    const match = entries.find((e) => e.toLowerCase() === name.toLowerCase());
-    return match ? path.join(dir, match) : null;
+    return execSync("git rev-parse --show-toplevel", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
   } catch {
     return null;
   }
 }
 
-async function resolveLinks(
-  content: string,
-  baseDir: string,
-  visited: Set<string>,
-  loaded: string[]
-): Promise<string> {
-  const linkPattern = /\[([^\]]*)\]\(([^)]+\.md)\)/g;
-  const replacements: Array<{ match: string; replacement: string }> = [];
+async function readContextFile(
+  fs: FsOps,
+  dir: string,
+  filename: string,
+): Promise<{ path: string; content: string } | null> {
+  for (const candidate of [dir, ...CONFIG_DIRS.map(d => fs.join(dir, d))]) {
+    const entries = await fs.list(candidate);
+    const match = entries.find(e => e.toLowerCase() === filename.toLowerCase());
+    if (!match) continue;
+    const filePath = fs.join(candidate, match);
+    const content = await fs.read(filePath);
+    if (content !== null) return { path: filePath, content };
+  }
+  return null;
+}
 
-  for (const match of content.matchAll(linkPattern)) {
-    const [full, , href] = match;
-    if (href.startsWith("http")) continue;
-
-    const absPath = path.resolve(baseDir, href);
-    if (visited.has(absPath)) continue;
-
-    const linked = await tryReadFile(absPath);
-    if (linked === null) continue;
-
-    visited.add(absPath);
-    loaded.push(absPath);
-    const resolved = await resolveLinks(linked, path.dirname(absPath), visited, loaded);
-    replacements.push({ match: full, replacement: resolved.trim() });
+/**
+ * Walks from gitRoot down to cwd, collecting one matching file per directory level.
+ * filenames: tried in priority order at each level (first match wins).
+ * Returns files in root → cwd order.
+ */
+export async function walkUpContextFiles(
+  fs: FsOps,
+  cwd: string,
+  filenames: string[],
+  gitRoot: string,
+): Promise<ContextFile[]> {
+  const dirs: string[] = [];
+  let current = cwd;
+  while (true) {
+    dirs.unshift(current);
+    if (current === gitRoot) break;
+    const parent = fs.dirname(current);
+    if (parent === current) break;
+    current = parent;
   }
 
-  let result = content;
-  for (const { match, replacement } of replacements) {
-    result = result.replace(match, replacement);
+  const result: ContextFile[] = [];
+  const visited = new Set<string>();
+
+  for (const dir of dirs) {
+    for (const filename of filenames) {
+      const file = await readContextFile(fs, dir, filename);
+      if (file === null || visited.has(file.path)) continue;
+      visited.add(file.path);
+      result.push({ path: fs.relative(cwd, file.path), content: file.content });
+      break; // one file per directory level
+    }
   }
+
   return result;
 }
 
 export async function loadContext(options: ContextOptions = {}): Promise<ContextResult> {
   const cwd = options.cwd ?? process.cwd();
-  const loaded: string[] = [];
-  const visited = new Set<string>();
+  const gitRoot = options.gitRoot ?? findGitRoot(cwd) ?? cwd;
+  const fs = localFs();
 
-  let conventions = "";
-  for (const filename of ["AGENTS.md", "CLAUDE.md"]) {
-    const absPath = await findFileCaseInsensitive(cwd, filename);
-    if (absPath === null) continue;
-    const content = await tryReadFile(absPath);
-    if (content !== null) {
-      visited.add(absPath);
-      loaded.push(absPath);
-      conventions = await resolveLinks(content, cwd, visited, loaded);
-      break;
-    }
-  }
+  const [conventions, reviewRules] = await Promise.all([
+    walkUpContextFiles(fs, cwd, ["AGENTS.md", "CLAUDE.md"], gitRoot),
+    walkUpContextFiles(fs, cwd, ["REVIEW.md"], gitRoot),
+  ]);
 
-  const reviewAbsPath = await findFileCaseInsensitive(cwd, "REVIEW.md");
-  let reviewRules = "";
-  if (reviewAbsPath !== null) {
-    const reviewRaw = await tryReadFile(reviewAbsPath);
-    if (reviewRaw !== null) {
-      visited.add(reviewAbsPath);
-      loaded.push(reviewAbsPath);
-      reviewRules = await resolveLinks(reviewRaw, cwd, visited, loaded);
-    }
-  }
+  return { conventions, reviewRules };
+}
 
-  const loadedFiles = loaded.map((f) => path.relative(cwd, f));
+export async function loadContextSSH(remote: string, remoteCwd: string, gitRoot?: string): Promise<ContextResult> {
+  const fs = sshFs(remote);
+  const resolvedGitRoot = gitRoot ?? await sshExec(remote, `git -C ${JSON.stringify(remoteCwd)} rev-parse --show-toplevel`)
+    .then(out => out.trim())
+    .catch(() => remoteCwd);
 
-  return { conventions, reviewRules, loadedFiles };
+  const [conventions, reviewRules] = await Promise.all([
+    walkUpContextFiles(fs, remoteCwd, ["AGENTS.md", "CLAUDE.md"], resolvedGitRoot),
+    walkUpContextFiles(fs, remoteCwd, ["REVIEW.md"], resolvedGitRoot),
+  ]);
+
+  return { conventions, reviewRules };
 }

--- a/src/core/prompt-builder.ts
+++ b/src/core/prompt-builder.ts
@@ -1,4 +1,4 @@
-import type { ContextResult } from "./context.js";
+import type { ContextFile, ContextResult } from "./context.js";
 
 export type MinSeverity = "CRITICAL" | "WARN" | "INFO";
 
@@ -7,6 +7,10 @@ const SEVERITY_RULE: Record<MinSeverity, string | null> = {
   WARN: "- Only report CRITICAL and WARN issues — skip INFO",
   CRITICAL: "- Only report CRITICAL issues — skip WARN and INFO",
 };
+
+function mergeContent(files: ContextFile[]): string {
+  return files.map(f => f.content).join("\n\n");
+}
 
 // ── Shared base ───────────────────────────────────────────────────────────────
 
@@ -64,12 +68,12 @@ export function buildJSONSystemPrompt(
     "- body: inline comment text, may use Markdown",
   ].join("\n");
 
-  const conventions = typeof context === "string" ? context : context.conventions;
-  const reviewRules = typeof context === "string" ? "" : context.reviewRules;
+  const conventionsStr = typeof context === "string" ? context : mergeContent(context.conventions);
+  const reviewRulesStr = typeof context === "string" ? "" : mergeContent(context.reviewRules);
 
   const sections: string[] = [base];
-  if (conventions.trim()) sections.push(`<conventions>\n${conventions}\n</conventions>`);
-  if (reviewRules.trim()) sections.push(`<review_rules>\n${reviewRules}\n</review_rules>`);
+  if (conventionsStr.trim()) sections.push(`<conventions>\n${conventionsStr}\n</conventions>`);
+  if (reviewRulesStr.trim()) sections.push(`<review_rules>\n${reviewRulesStr}\n</review_rules>`);
 
   return sections.join("\n\n");
 }
@@ -78,8 +82,8 @@ export function buildJSONSystemPrompt(
  * Markdown system prompt — used by SSH-only mode.
  * Agent writes a human-readable markdown review and saves it to pi-review.md.
  */
-export function buildMarkdownSystemPrompt(minSeverity: MinSeverity = "INFO"): string {
-  return [
+export function buildMarkdownSystemPrompt(minSeverity: MinSeverity = "INFO", context?: ContextResult | string): string {
+  const base = [
     ...buildSharedBase(minSeverity),
     "",
     "Write your review as Markdown with:",
@@ -88,6 +92,14 @@ export function buildMarkdownSystemPrompt(minSeverity: MinSeverity = "INFO"): st
     "",
     "After writing your review, save it to pi-review.md in the project root using the Write tool.",
   ].join("\n");
+
+  if (!context) return base;
+  const conventionsStr = typeof context === "string" ? context : mergeContent(context.conventions);
+  const reviewRulesStr = typeof context === "string" ? "" : mergeContent(context.reviewRules);
+  const sections: string[] = [base];
+  if (conventionsStr.trim()) sections.push(`<conventions>\n${conventionsStr}\n</conventions>`);
+  if (reviewRulesStr.trim()) sections.push(`<review_rules>\n${reviewRulesStr}\n</review_rules>`);
+  return sections.join("\n\n");
 }
 
 // ── User prompts ──────────────────────────────────────────────────────────────
@@ -116,9 +128,6 @@ export function buildSSHUserPrompt(diffCommand: string): string {
     `    <command>${diffCommand}</command>`,
     "  </step>",
     "  <step index=\"2\">",
-    "    Read AGENTS.md or CLAUDE.md from the project root if either exists. Scan for markdown links matching [text](./path.md) and read each linked .md file recursively (at any depth). Also read REVIEW.md from the project root if it exists (same recursive rule). These files contain project conventions and review-specific rules.",
-    "  </step>",
-    "  <step index=\"3\">",
     "    Review the diff according to the system prompt instructions.",
     "  </step>",
     "</request>",

--- a/src/core/ssh.ts
+++ b/src/core/ssh.ts
@@ -1,0 +1,88 @@
+import { execFile } from "node:child_process";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { dirname as posixDirname, join as posixJoin, relative as posixRelative } from "node:path/posix";
+
+export interface FsOps {
+  read(p: string): Promise<string | null>;
+  list(dir: string): Promise<string[]>;
+  join(...parts: string[]): string;
+  dirname(p: string): string;
+  relative(from: string, to: string): string;
+}
+
+export interface SshState {
+  remote: string;
+  remoteCwd: string;
+}
+
+export function localFs(): FsOps {
+  return {
+    async read(p) {
+      try { return await readFile(p, "utf-8"); }
+      catch { return null; }
+    },
+    async list(dir) {
+      try { return await readdir(dir); }
+      catch { return []; }
+    },
+    join,
+    dirname,
+    relative,
+  };
+}
+
+export function sshExec(remote: string, command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("ssh", [remote, command], { encoding: "utf8" }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout as string);
+    });
+  });
+}
+
+export function sshFs(remote: string): FsOps {
+  return {
+    async read(p) {
+      try { return await sshExec(remote, `cat ${JSON.stringify(p)}`); }
+      catch { return null; }
+    },
+    async list(dir) {
+      try {
+        const out = await sshExec(remote, `ls -1 ${JSON.stringify(dir)}`);
+        return out.split("\n").map(l => l.trim()).filter(Boolean);
+      } catch { return []; }
+    },
+    join: posixJoin,
+    dirname: posixDirname,
+    relative: posixRelative,
+  };
+}
+
+/**
+ * Reads --ssh user@host (or --ssh=user@host) from process.argv.
+ */
+export function readSshFlag(): string | undefined {
+  const args = process.argv;
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === "--ssh" && i + 1 < args.length) return args[i + 1];
+    if (args[i].startsWith("--ssh=")) return args[i].slice(6);
+  }
+  return undefined;
+}
+
+/**
+ * Resolves SSH state from the --ssh flag value.
+ * Supports user@host:/path and user@host (cwd resolved via pwd).
+ */
+export async function resolveSshState(flag: string): Promise<SshState> {
+  const colonIdx = flag.indexOf(":");
+  if (colonIdx !== -1) {
+    const remote = flag.slice(0, colonIdx);
+    const rawCwd = flag.slice(colonIdx + 1);
+    const remoteCwd = (await sshExec(remote, `cd ${rawCwd} && pwd`)).trim();
+    return { remote, remoteCwd };
+  }
+  const remoteCwd = (await sshExec(flag, "pwd")).trim();
+  return { remote: flag, remoteCwd };
+}

--- a/tests/ci/review.test.ts
+++ b/tests/ci/review.test.ts
@@ -54,7 +54,7 @@ describe("review", () => {
       diff: "diff --git a/a.ts b/a.ts",
       source: "git diff origin/main...HEAD",
     });
-    loadContextMock.mockResolvedValue({ conventions: "- Use strict typing", reviewRules: "", loadedFiles: ["AGENTS.md"] });
+    loadContextMock.mockResolvedValue({ conventions: [{ path: "AGENTS.md", content: "- Use strict typing" }], reviewRules: [] });
     sendOutputMock.mockResolvedValue(undefined);
     createReadOnlyToolsMock.mockReturnValue([]);
     AgentMock.mockImplementation(function () {
@@ -132,7 +132,7 @@ describe("review", () => {
   });
 
   it("continues normally when AGENTS.md context is missing", async () => {
-    loadContextMock.mockResolvedValue({ conventions: "", reviewRules: "", loadedFiles: [] });
+    loadContextMock.mockResolvedValue({ conventions: [], reviewRules: [] });
 
     await review({ cwd: "/repo" });
 

--- a/tests/core/context.test.ts
+++ b/tests/core/context.test.ts
@@ -1,9 +1,11 @@
+import { execSync } from "node:child_process";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { loadContext } from "../../src/core/context.js";
+import { loadContext, walkUpContextFiles } from "../../src/core/context.js";
+import { localFs } from "../../src/core/ssh.js";
 
 const createdDirs: string[] = [];
 
@@ -25,9 +27,8 @@ describe("loadContext", () => {
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe(content);
-    expect(result.reviewRules).toBe("");
-    expect(result.loadedFiles).toEqual(["AGENTS.md"]);
+    expect(result.conventions).toEqual([{ path: "AGENTS.md", content }]);
+    expect(result.reviewRules).toEqual([]);
   });
 
   it("returns conventions from CLAUDE.md when AGENTS.md does not exist", async () => {
@@ -37,9 +38,8 @@ describe("loadContext", () => {
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe(content);
-    expect(result.reviewRules).toBe("");
-    expect(result.loadedFiles).toEqual(["CLAUDE.md"]);
+    expect(result.conventions).toEqual([{ path: "CLAUDE.md", content }]);
+    expect(result.reviewRules).toEqual([]);
   });
 
   it("prefers AGENTS.md over CLAUDE.md when both exist", async () => {
@@ -49,18 +49,16 @@ describe("loadContext", () => {
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe("agents content");
-    expect(result.loadedFiles).toEqual(["AGENTS.md"]);
+    expect(result.conventions).toEqual([{ path: "AGENTS.md", content: "agents content" }]);
   });
 
-  it("returns empty conventions when neither AGENTS.md nor CLAUDE.md exists", async () => {
+  it("returns empty arrays when neither AGENTS.md nor CLAUDE.md exists", async () => {
     const dir = await createTempDir();
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe("");
-    expect(result.reviewRules).toBe("");
-    expect(result.loadedFiles).toEqual([]);
+    expect(result.conventions).toEqual([]);
+    expect(result.reviewRules).toEqual([]);
   });
 
   it("returns reviewRules when REVIEW.md exists", async () => {
@@ -70,9 +68,8 @@ describe("loadContext", () => {
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe("conventions");
-    expect(result.reviewRules).toBe("# Review rules\n- Always check res.ok\n");
-    expect(result.loadedFiles).toEqual(["AGENTS.md", "REVIEW.md"]);
+    expect(result.conventions).toEqual([{ path: "AGENTS.md", content: "conventions" }]);
+    expect(result.reviewRules).toEqual([{ path: "REVIEW.md", content: "# Review rules\n- Always check res.ok\n" }]);
   });
 
   it("returns reviewRules even when no conventions file exists", async () => {
@@ -81,9 +78,8 @@ describe("loadContext", () => {
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe("");
-    expect(result.reviewRules).toBe("review only rules");
-    expect(result.loadedFiles).toEqual(["REVIEW.md"]);
+    expect(result.conventions).toEqual([]);
+    expect(result.reviewRules).toEqual([{ path: "REVIEW.md", content: "review only rules" }]);
   });
 
   it("uses process.cwd() when cwd option is not provided", async () => {
@@ -94,80 +90,200 @@ describe("loadContext", () => {
     try {
       process.chdir(dir);
       const result = await loadContext();
-      expect(result.conventions).toBe("project context");
+      expect(result.conventions[0].content).toBe("project context");
     } finally {
       process.chdir(oldCwd);
     }
   });
 
-  it("inlines linked .md files referenced in AGENTS.md", async () => {
+  it("loads AGENTS.md from .pi/ when not at root", async () => {
     const dir = await createTempDir();
-    await writeFile(path.join(dir, "AGENTS.md"), "Main content\n\n[api conventions](./docs/api.md)\n", "utf-8");
-    await mkdir(path.join(dir, "docs"));
-    await writeFile(path.join(dir, "docs", "api.md"), "API rules here", "utf-8");
+    await mkdir(path.join(dir, ".pi"));
+    await writeFile(path.join(dir, ".pi", "AGENTS.md"), "pi-dir conventions", "utf-8");
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toContain("Main content");
-    expect(result.conventions).toContain("API rules here");
-    expect(result.conventions).not.toContain("[api conventions](./docs/api.md)");
-    expect(result.loadedFiles).toEqual(["AGENTS.md", path.join("docs", "api.md")]);
+    expect(result.conventions).toEqual([{ path: path.join(".pi", "AGENTS.md"), content: "pi-dir conventions" }]);
   });
 
-  it("inlines nested linked .md files recursively", async () => {
+  it("prefers root AGENTS.md over .pi/AGENTS.md", async () => {
     const dir = await createTempDir();
-    await writeFile(path.join(dir, "AGENTS.md"), "Root\n\n[level1](./level1.md)\n", "utf-8");
-    await writeFile(path.join(dir, "level1.md"), "Level1\n\n[level2](./level2.md)\n", "utf-8");
-    await writeFile(path.join(dir, "level2.md"), "Level2 content", "utf-8");
+    await mkdir(path.join(dir, ".pi"));
+    await writeFile(path.join(dir, "AGENTS.md"), "root conventions", "utf-8");
+    await writeFile(path.join(dir, ".pi", "AGENTS.md"), "pi-dir conventions", "utf-8");
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toContain("Root");
-    expect(result.conventions).toContain("Level1");
-    expect(result.conventions).toContain("Level2 content");
-    expect(result.loadedFiles).toEqual(["AGENTS.md", "level1.md", "level2.md"]);
+    expect(result.conventions[0].content).toBe("root conventions");
   });
 
-  it("does not inline http links", async () => {
+  it("loads REVIEW.md from .pi/ when not at root", async () => {
     const dir = await createTempDir();
-    const content = "See [docs](https://example.com/docs.md) for more.\n";
-    await writeFile(path.join(dir, "AGENTS.md"), content, "utf-8");
+    await mkdir(path.join(dir, ".pi"));
+    await writeFile(path.join(dir, ".pi", "REVIEW.md"), "pi-dir review rules", "utf-8");
 
     const result = await loadContext({ cwd: dir });
 
-    expect(result.conventions).toBe(content);
+    expect(result.reviewRules).toEqual([{ path: path.join(".pi", "REVIEW.md"), content: "pi-dir review rules" }]);
+  });
+});
+
+describe("loadContext — monorepo (git root walk-up)", () => {
+  it("collects AGENTS.md from both root and package dir", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "pi-reviewer-mono-"));
+    createdDirs.push(root);
+    execSync("git init", { cwd: root, stdio: "ignore" });
+
+    const pkgDir = path.join(root, "packages", "api");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "root conventions", "utf-8");
+    await writeFile(path.join(pkgDir, "AGENTS.md"), "api conventions", "utf-8");
+
+    const result = await loadContext({ cwd: pkgDir });
+
+    expect(result.conventions).toHaveLength(2);
+    expect(result.conventions[0]).toEqual({ path: path.join("..", "..", "AGENTS.md"), content: "root conventions" });
+    expect(result.conventions[1]).toEqual({ path: "AGENTS.md", content: "api conventions" });
   });
 
-  it("ignores missing linked files gracefully", async () => {
-    const dir = await createTempDir();
-    const content = "Main\n\n[missing](./nonexistent.md)\n";
-    await writeFile(path.join(dir, "AGENTS.md"), content, "utf-8");
+  it("collects REVIEW.md from both root and package dir", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "pi-reviewer-mono-"));
+    createdDirs.push(root);
+    execSync("git init", { cwd: root, stdio: "ignore" });
 
-    const result = await loadContext({ cwd: dir });
+    const pkgDir = path.join(root, "packages", "api");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(root, "REVIEW.md"), "root review rules", "utf-8");
+    await writeFile(path.join(pkgDir, "REVIEW.md"), "api review rules", "utf-8");
 
-    expect(result.conventions).toBe(content);
+    const result = await loadContext({ cwd: pkgDir });
+
+    expect(result.reviewRules).toHaveLength(2);
+    expect(result.reviewRules[0].content).toBe("root review rules");
+    expect(result.reviewRules[1].content).toBe("api review rules");
   });
 
-  it("prevents infinite loops from circular links", async () => {
-    const dir = await createTempDir();
-    await writeFile(path.join(dir, "AGENTS.md"), "Root\n\n[a](./a.md)\n", "utf-8");
-    await writeFile(path.join(dir, "a.md"), "A content\n\n[back](./AGENTS.md)\n", "utf-8");
+  it("works with only root AGENTS.md when running from a package dir", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "pi-reviewer-mono-"));
+    createdDirs.push(root);
+    execSync("git init", { cwd: root, stdio: "ignore" });
 
-    const result = await loadContext({ cwd: dir });
+    const pkgDir = path.join(root, "packages", "api");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "root conventions", "utf-8");
 
-    expect(result.conventions).toContain("Root");
-    expect(result.conventions).toContain("A content");
+    const result = await loadContext({ cwd: pkgDir });
+
+    expect(result.conventions).toHaveLength(1);
+    expect(result.conventions[0].content).toBe("root conventions");
   });
 
-  it("inlines links in REVIEW.md", async () => {
+  it("finds root AGENTS.md and package REVIEW.md when cwd is the package dir (--dir equivalent)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "pi-reviewer-mono-"));
+    createdDirs.push(root);
+    execSync("git init", { cwd: root, stdio: "ignore" });
+
+    const pkgDir = path.join(root, "project-x");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "root conventions", "utf-8");
+    await writeFile(path.join(pkgDir, "REVIEW.md"), "package review rules", "utf-8");
+
+    const result = await loadContext({ cwd: pkgDir });
+
+    expect(result.conventions).toHaveLength(1);
+    expect(result.conventions[0].content).toBe("root conventions");
+    expect(result.reviewRules).toHaveLength(1);
+    expect(result.reviewRules[0].content).toBe("package review rules");
+  });
+
+  it("gitRoot override walks up to the specified boundary (--dir with nested git repo)", async () => {
+    const root = await createTempDir();
+    const pkgDir = path.join(root, "project-x");
+    await mkdir(pkgDir, { recursive: true });
+
+    await writeFile(path.join(root, "AGENTS.md"), "root conventions", "utf-8");
+    await writeFile(path.join(root, "REVIEW.md"), "root review rules", "utf-8");
+    await writeFile(path.join(pkgDir, "AGENTS.md"), "pkg conventions", "utf-8");
+
+    // gitRoot override forces walk-up to root even when pkgDir has its own .git
+    const result = await loadContext({ cwd: pkgDir, gitRoot: root });
+
+    expect(result.conventions).toHaveLength(2);
+    expect(result.conventions[0].content).toBe("root conventions");
+    expect(result.conventions[1].content).toBe("pkg conventions");
+    expect(result.reviewRules).toHaveLength(1);
+    expect(result.reviewRules[0].content).toBe("root review rules");
+  });
+});
+
+describe("walkUpContextFiles", () => {
+  it("returns empty array when no files exist", async () => {
     const dir = await createTempDir();
-    await writeFile(path.join(dir, "REVIEW.md"), "Rules\n\n[details](./review-details.md)\n", "utf-8");
-    await writeFile(path.join(dir, "review-details.md"), "Detailed rules", "utf-8");
 
-    const result = await loadContext({ cwd: dir });
+    const result = await walkUpContextFiles(localFs(), dir, ["AGENTS.md", "CLAUDE.md"], dir);
 
-    expect(result.reviewRules).toContain("Rules");
-    expect(result.reviewRules).toContain("Detailed rules");
-    expect(result.loadedFiles).toEqual(["REVIEW.md", "review-details.md"]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns single file when found at cwd level", async () => {
+    const dir = await createTempDir();
+    await writeFile(path.join(dir, "AGENTS.md"), "conventions", "utf-8");
+
+    const result = await walkUpContextFiles(localFs(), dir, ["AGENTS.md", "CLAUDE.md"], dir);
+
+    expect(result).toEqual([{ path: "AGENTS.md", content: "conventions" }]);
+  });
+
+  it("picks first matching filename at each level", async () => {
+    const dir = await createTempDir();
+    await writeFile(path.join(dir, "AGENTS.md"), "agents", "utf-8");
+    await writeFile(path.join(dir, "CLAUDE.md"), "claude", "utf-8");
+
+    const result = await walkUpContextFiles(localFs(), dir, ["AGENTS.md", "CLAUDE.md"], dir);
+
+    expect(result).toEqual([{ path: "AGENTS.md", content: "agents" }]);
+  });
+
+  it("collects one file per directory level, root → cwd", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "pi-reviewer-walk-"));
+    createdDirs.push(root);
+    execSync("git init", { cwd: root, stdio: "ignore" });
+
+    const pkgDir = path.join(root, "packages", "api");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "root", "utf-8");
+    await writeFile(path.join(pkgDir, "AGENTS.md"), "api", "utf-8");
+
+    const result = await walkUpContextFiles(localFs(), pkgDir, ["AGENTS.md", "CLAUDE.md"], root);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe("root");
+    expect(result[1].content).toBe("api");
+  });
+
+  it("stops at gitRoot — does not collect files above it", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "pi-reviewer-walk-"));
+    createdDirs.push(root);
+    execSync("git init", { cwd: root, stdio: "ignore" });
+
+    const pkgDir = path.join(root, "packages", "api");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "root", "utf-8");
+
+    // gitRoot is root, so walk stops at root even though parent dirs might have files
+    const result = await walkUpContextFiles(localFs(), pkgDir, ["AGENTS.md", "CLAUDE.md"], root);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("root");
+  });
+
+  it("finds files in config subdirs (.pi, .claude, .agents)", async () => {
+    const dir = await createTempDir();
+    await mkdir(path.join(dir, ".pi"));
+    await writeFile(path.join(dir, ".pi", "AGENTS.md"), "pi conventions", "utf-8");
+
+    const result = await walkUpContextFiles(localFs(), dir, ["AGENTS.md", "CLAUDE.md"], dir);
+
+    expect(result).toEqual([{ path: path.join(".pi", "AGENTS.md"), content: "pi conventions" }]);
   });
 });

--- a/tests/core/prompt-builder.test.ts
+++ b/tests/core/prompt-builder.test.ts
@@ -4,7 +4,7 @@ import { buildJSONSystemPrompt, buildMarkdownSystemPrompt, buildSSHUserPrompt, b
 
 describe("prompt-builder", () => {
   it("returns base prompt without sections when context is empty", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" });
+    const prompt = buildJSONSystemPrompt({ conventions: [], reviewRules: [] });
 
     expect(prompt).toContain("You are a code reviewer");
     expect(prompt).toContain("Return only a JSON object matching this schema exactly");
@@ -13,7 +13,7 @@ describe("prompt-builder", () => {
   });
 
   it("appends conventions section when conventions is provided", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "use tabs", reviewRules: "" });
+    const prompt = buildJSONSystemPrompt({ conventions: [{ path: "AGENTS.md", content: "use tabs" }], reviewRules: [] });
 
     expect(prompt).toContain("<conventions>");
     expect(prompt).toContain("use tabs");
@@ -21,7 +21,7 @@ describe("prompt-builder", () => {
   });
 
   it("appends review rules section when reviewRules is provided", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "always check res.ok" });
+    const prompt = buildJSONSystemPrompt({ conventions: [], reviewRules: [{ path: "REVIEW.md", content: "always check res.ok" }] });
 
     expect(prompt).toContain("<review_rules>");
     expect(prompt).toContain("always check res.ok");
@@ -29,7 +29,10 @@ describe("prompt-builder", () => {
   });
 
   it("appends both sections when both are provided", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "use tabs", reviewRules: "always check res.ok" });
+    const prompt = buildJSONSystemPrompt({
+      conventions: [{ path: "AGENTS.md", content: "use tabs" }],
+      reviewRules: [{ path: "REVIEW.md", content: "always check res.ok" }],
+    });
 
     expect(prompt).toContain("<conventions>");
     expect(prompt).toContain("use tabs");
@@ -66,27 +69,27 @@ describe("prompt-builder", () => {
   });
 
   it("system prompt includes JSON keys summary and comments", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" });
+    const prompt = buildJSONSystemPrompt({ conventions: [], reviewRules: [] });
 
     expect(prompt).toContain('"summary"');
     expect(prompt).toContain('"comments"');
   });
 
   it("buildJSONSystemPrompt with minSeverity WARN adds skip-INFO rule", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" }, "WARN");
+    const prompt = buildJSONSystemPrompt({ conventions: [], reviewRules: [] }, "WARN");
 
     expect(prompt).toContain("skip INFO");
     expect(prompt).not.toContain("skip WARN");
   });
 
   it("buildJSONSystemPrompt with minSeverity CRITICAL adds skip-WARN-and-INFO rule", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" }, "CRITICAL");
+    const prompt = buildJSONSystemPrompt({ conventions: [], reviewRules: [] }, "CRITICAL");
 
     expect(prompt).toContain("skip WARN and INFO");
   });
 
   it("buildJSONSystemPrompt with default minSeverity adds no skip rule", () => {
-    const prompt = buildJSONSystemPrompt({ conventions: "", reviewRules: "" });
+    const prompt = buildJSONSystemPrompt({ conventions: [], reviewRules: [] });
 
     expect(prompt).not.toContain("skip INFO");
     expect(prompt).not.toContain("skip WARN");
@@ -122,12 +125,12 @@ describe("buildMarkdownSystemPrompt", () => {
 });
 
 describe("buildSSHUserPrompt", () => {
-  it("includes read AGENTS.md instruction", () => {
+  it("does not include file-reading instructions (context loaded directly)", () => {
     const prompt = buildSSHUserPrompt("git diff HEAD~1");
 
-    expect(prompt).toContain("AGENTS.md");
-    expect(prompt).toContain("CLAUDE.md");
-    expect(prompt).toContain("REVIEW.md");
+    expect(prompt).not.toContain("AGENTS.md");
+    expect(prompt).not.toContain("CLAUDE.md");
+    expect(prompt).not.toContain("REVIEW.md");
   });
 
   it("includes the diff command", () => {


### PR DESCRIPTION
…context loading, --dir fix

  - Replace ContextResult { conventions: string, reviewRules: string, loadedFiles: string[] } with { conventions: ContextFile[], reviewRules: ContextFile[] } — path+content together, matches pi-context's { path, content }[] shape, enables Context tab grouping

  - Extract FsOps abstraction (localFs / sshFs) so walkUpContextFiles works for both local and SSH with the same implementation

  - walkUpContextFiles: walks from gitRoot down to cwd, one file per directory level, root → cwd order — monorepo support out of the box

  - loadContextSSH: reads AGENTS.md / REVIEW.md directly via sshFs before the agent starts (replaces bash-prompt approach); also walks up to SSH git root for monorepo

  - --dir fix: loadContext cwd resolved to the sub-project dir; gitRoot override set to ctx.cwd so walk-up crosses the inner .git boundary and reaches parent conventions

  - Remove collectLinkedFiles — markdown link inlining removed in favour of explicit context providers (TODO #21)