### PR TITLE
  feat(ui): add Context panel with pluggable provider groups (#22)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -287,22 +287,28 @@ tests/
 - [x] **File tree folder compression** — collapse single-child directory chains into combined names (e.g. `providers/oauth/handlers`) à la VS Code; contained hover highlight with margin + border-radius; widen sidebar to 296 px; bump tree and comment body font size to 13 px
 - [x] **Version in wordmark** — display `vX.Y.Z` next to the wordmark, injected at build time from `package.json` via Vite `define`
 
-### 21. Pluggable context provider API
+### 21. Pluggable context provider API ✅
 
 See [`docs/context-providers/README.md`](./docs/context-providers/README.md) for the full design.
 
-- [ ] Export `ContextFile { path, content }`, `ContextProvider`, `ContextProviderEvent`, `CONTEXT_PROVIDER_EVENT` from `src/core/context.ts`
-- [ ] Add `extractDiffFiles(diff: string): string[]` to `src/core/diff-resolver.ts` — parses `diff --git` headers to extract changed file paths
-- [ ] Update `buildJSONSystemPrompt` in `src/core/prompt-builder.ts` to accept optional `contextFiles: ContextFile[]` — append each `content` to the system prompt
-- [ ] In `extensions/pi-reviewer/index.ts` (local path): emit `CONTEXT_PROVIDER_EVENT` with `{ cwd, diffFiles, register(name, provider) }`, collect results, pass to `buildJSONSystemPrompt`
-- [ ] Tests: `extractDiffFiles` unit tests; `buildJSONSystemPrompt` tests for extra content injection
+- [x] `ContextFile`, `ContextGroup`, `ContextProvider`, `ContextProviderEvent`, `CONTEXT_PROVIDER_EVENT`, `MinimalEventBus` exported from `src/core/context.ts`
+- [x] `collectProviderContext(events, cwd, diffFiles): Promise<ContextGroup[]>` — sync emit, async provider calls, groups filtered if empty
+- [x] `mergeContextFiles(result: ContextResult): ContextFile[]` — replaces repeated `[...conventions, ...reviewRules]` spreads
+- [x] `extractDiffFiles(diff: string): string[]` added to `src/core/diff-resolver.ts`
+- [x] `buildJSONSystemPrompt` and `buildMarkdownSystemPrompt` accept optional `contextFiles: ContextFile[]`
+- [x] All 4 paths in `extensions/pi-reviewer/index.ts` wired: dry-run SSH, dry-run local, SSH, local
+- [x] Refactors: `buildSSHDiffCommand` → `args.ts`, `resolveCurrentModelId` → `model.ts`, `extractAssistantText` → `src/core/output.ts`
+- [x] Tests: `extractDiffFiles`, `collectProviderContext`, `buildJSONSystemPrompt`/`buildMarkdownSystemPrompt` with context files, integration test in `tests/extensions/index.test.ts`
 
-### 22. UI: Context tab
+### 22. UI: Context tab ✅
 
-- [ ] Add a **Context** tab in the review UI (alongside the file tree / summary) listing all files loaded for the review
-- [ ] Eagerly loaded section: `AGENTS.md`, `REVIEW.md`, and markdown-linked files (from `loadedFiles` in `ContextResult`)
-- [ ] Provider-contributed section: files listed in `<context-files>` block; mark each as "loaded" if the agent called Read on it during the review
-- [ ] Lets users verify the right context reached the agent before acting on findings
+- [x] Context right panel in the review UI — toggles exclusively with Overview (one panel at a time)
+- [x] Built-in group: `AGENTS.md`, `REVIEW.md` (all files from `mergeContextFiles`) shown under "built-in"
+- [x] Provider group: one section per registered `ContextProvider` (name from `register(name, provider)`)
+- [x] Each file expandable — click path to reveal content injected into the system prompt
+- [x] `SidePanelLayout` / `SidePanel` shared shell — FileTree, Summary, and Context all use the same 296 px sticky container
+- [ ] ~~markdown-linked files~~ — superseded; context files are now typed `ContextFile[]` end-to-end, no separate `loadedFiles` field needed
+- [ ] Mark provider files as "loaded" if the agent called Read on them during the review — deferred, requires tool-call interception
 
 ### 23. Built-in doc-context ContextProvider extension
 

--- a/extensions/pi-reviewer/index.ts
+++ b/extensions/pi-reviewer/index.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-import { loadContext, collectProviderContext, mergeContextFiles } from "../../src/core/context.js";
+import { loadContext, collectProviderContext, mergeContextFiles, type ContextGroup } from "../../src/core/context.js";
 import { resolveDiff, detectCurrentBranch, detectOriginBase, extractDiffFiles } from "../../src/core/diff-resolver.js";
 import { filterDiff } from "../../src/core/diff-filter.js";
 import { formatForTerminal } from "../../src/core/output.js";
@@ -51,14 +51,14 @@ export default function (pi: ExtensionAPI): void {
 
         if (parsed.dryRun) {
           if (parsed.ssh) {
-            const drySSHContextFiles = await collectProviderContext(pi.events, ctx.cwd, []);
+            const drySSHContextFiles = (await collectProviderContext(pi.events, ctx.cwd, [])).flatMap(g => g.files);
             notify(`System prompt:\n\n${buildMarkdownSystemPrompt(minSeverity, undefined, drySSHContextFiles)}`);
             notify(`User prompt:\n\n${buildSSHUserPrompt(buildSSHDiffCommand(parsed))}`);
           } else {
             const { diff, source, skippedFiles } = await resolveDiff({ cwd: ctx.cwd, diff: parsed.diff, branch: parsed.branch ?? readDefaultBranch(), pr: parsed.pr, dir: parsed.dir });
             const context = await loadContext({ cwd: parsed.dir ? path.resolve(ctx.cwd, parsed.dir) : ctx.cwd, gitRoot: parsed.dir ? ctx.cwd : undefined });
             const dryDiffFiles = extractDiffFiles(diff);
-            const dryContextFiles = await collectProviderContext(pi.events, ctx.cwd, dryDiffFiles);
+            const dryContextFiles = (await collectProviderContext(pi.events, ctx.cwd, dryDiffFiles)).flatMap(g => g.files);
             notify(`Diff source: ${source}`);
             notify(`System prompt:\n\n${buildJSONSystemPrompt(context, minSeverity, dryContextFiles)}`);
             notify(`User prompt:\n\n${buildUserPrompt(diff, skippedFiles)}`);
@@ -85,8 +85,14 @@ export default function (pi: ExtensionAPI): void {
           if (sshLoadedPaths.length > 0) notify(`Context: ${sshLoadedPaths.join(", ")}`);
 
           // diffFiles unavailable in SSH mode (agent fetches diff itself) — providers run with []
-          const sshContextFiles = await collectProviderContext(pi.events, ctx.cwd, []);
+          const sshProviderGroups = await collectProviderContext(pi.events, ctx.cwd, []);
+          const sshContextFiles = sshProviderGroups.flatMap(g => g.files);
           if (sshContextFiles.length > 0) notify(`Provider context: ${sshContextFiles.map(f => f.path).join(", ")}`);
+          const sshBuiltInFiles = mergeContextFiles(sshContext);
+          const sshAllContextGroups: ContextGroup[] = [
+            ...(sshBuiltInFiles.length > 0 ? [{ name: "built-in", files: sshBuiltInFiles }] : []),
+            ...sshProviderGroups,
+          ];
 
           if (!parsed.ui) {
             // SSH-only: agent fetches diff, reviews, saves markdown
@@ -108,6 +114,7 @@ export default function (pi: ExtensionAPI): void {
           const injectionMsg = await handleUIReview({
             result, diff, conventions, source, ssh: true, cwd: ctx.cwd, notify,
             currentModel: currentModelId, currentThinking: thinking, defaultModel, availableModels, defaultThinking: readThinking(),
+            contextGroups: sshAllContextGroups,
             saveRemote: (md) => {
               sshSaveTriggered = true;
               pi.sendUserMessage(`Run \`git rev-parse --show-toplevel\` to get the project root path, then write the following content to that path + "/pi-review.md" (e.g. if the root is /some/path, write to /some/path/pi-review.md):\n\n${md}`);
@@ -139,16 +146,22 @@ export default function (pi: ExtensionAPI): void {
         if (loadedPaths.length > 0) notify(`Context: ${loadedPaths.join(", ")}`);
         const conventions = mergeContextFiles(context).map(f => f.content).join("\n\n");
         const diffFiles = extractDiffFiles(diff);
-        const contextFiles = await collectProviderContext(pi.events, ctx.cwd, diffFiles);
+        const providerGroups = await collectProviderContext(pi.events, ctx.cwd, diffFiles);
+        const contextFiles = providerGroups.flatMap(g => g.files);
         if (contextFiles.length > 0) notify(`Provider context: ${contextFiles.map(f => f.path).join(", ")}`);
         const systemPrompt = buildJSONSystemPrompt(context, minSeverity, contextFiles);
+        const builtInFiles = mergeContextFiles(context);
+        const allContextGroups: ContextGroup[] = [
+          ...(builtInFiles.length > 0 ? [{ name: "built-in", files: builtInFiles }] : []),
+          ...providerGroups,
+        ];
         const userPrompt = buildUserPrompt(diff, skippedFiles);
 
         stopLoader = setReviewFooter(ctx, source, { model: currentModelId, thinking });
         const result = await runLocalReview({ systemPrompt, userPrompt, cwd: ctx.cwd, minSeverity, verbose, model, thinking, stopLoader, notify });
 
         if (parsed.ui) {
-          const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, currentModel: currentModelId, defaultModel, availableModels });
+          const injectionMsg = await handleUIReview({ result, diff, conventions, source, cwd: ctx.cwd, notify, currentModel: currentModelId, defaultModel, availableModels, contextGroups: allContextGroups });
           if (injectionMsg) pi.sendUserMessage(injectionMsg);
           return;
         }

--- a/extensions/pi-reviewer/ui-handler.ts
+++ b/extensions/pi-reviewer/ui-handler.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { type ReviewResult } from "../../src/core/output.js";
-import { startUIServer, type CommentDecision, type ModelInfo } from "../../src/core/ui-server.js";
+import { startUIServer, type CommentDecision, type ModelInfo, type ContextGroup } from "../../src/core/ui-server.js";
 
 export interface UIHandlerOptions {
   result: ReviewResult;
@@ -17,6 +17,7 @@ export interface UIHandlerOptions {
   defaultModel?: string;
   availableModels?: ModelInfo[];
   defaultThinking?: string;
+  contextGroups?: ContextGroup[];
   /** When set, save is delegated to the remote (SSH) instead of written locally. */
   saveRemote?: (markdown: string) => void;
 }
@@ -27,9 +28,9 @@ export interface UIHandlerOptions {
  * message at the right time (after any agent-side save has completed).
  */
 export async function handleUIReview(opts: UIHandlerOptions): Promise<string | undefined> {
-  const { result, diff, conventions, source, ssh, cwd, notify, saveRemote, currentModel, currentThinking, defaultModel, availableModels, defaultThinking } = opts;
+  const { result, diff, conventions, source, ssh, cwd, notify, saveRemote, currentModel, currentThinking, defaultModel, availableModels, defaultThinking, contextGroups } = opts;
 
-  const handle = await startUIServer(result, diff, source, ssh, { currentModel, currentThinking, defaultModel, availableModels, defaultThinking });
+  const handle = await startUIServer(result, diff, source, ssh, { currentModel, currentThinking, defaultModel, availableModels, defaultThinking }, contextGroups);
   notify(`Review UI → ${handle.url}`);
 
   const action = await handle.waitForAction();

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -13,6 +13,11 @@ export interface ContextFile {
   content: string;
 }
 
+export interface ContextGroup {
+  name: string;
+  files: ContextFile[];
+}
+
 export interface ContextResult {
   conventions: ContextFile[]; // AGENTS.md / CLAUDE.md, root → cwd order
   reviewRules: ContextFile[]; // REVIEW.md, root → cwd order
@@ -107,14 +112,20 @@ export async function collectProviderContext(
   events: MinimalEventBus,
   cwd: string,
   diffFiles: string[],
-): Promise<ContextFile[]> {
+): Promise<ContextGroup[]> {
   const registrations: Array<{ name: string; provider: ContextProvider }> = [];
   events.emit(CONTEXT_PROVIDER_EVENT, {
     cwd,
     diffFiles,
     register: (name: string, provider: ContextProvider) => registrations.push({ name, provider }),
   } satisfies ContextProviderEvent);
-  return (await Promise.all(registrations.map(({ provider }) => provider({ cwd, diffFiles })))).flat();
+  const groups = await Promise.all(
+    registrations.map(async ({ name, provider }) => ({
+      name,
+      files: await provider({ cwd, diffFiles }),
+    })),
+  );
+  return groups.filter(g => g.files.length > 0);
 }
 
 export async function loadContext(options: ContextOptions = {}): Promise<ContextResult> {

--- a/src/core/ui-server.ts
+++ b/src/core/ui-server.ts
@@ -1,2 +1,2 @@
-export type { UIServerHandle, UIAction, ActionType, CommentDecision, ModelInfo, UIModelConfig } from "./ui/server/index.js";
+export type { UIServerHandle, UIAction, ActionType, CommentDecision, ModelInfo, UIModelConfig, ContextGroup } from "./ui/server/index.js";
 export { startUIServer } from "./ui/server/index.js";

--- a/src/core/ui/server/index.ts
+++ b/src/core/ui/server/index.ts
@@ -3,11 +3,13 @@ import { exec } from "node:child_process";
 import { platform } from "node:os";
 import type { ReviewResult } from "../../output.js";
 import { buildHTML } from "../template.js";
+import type { ContextGroup } from "../../context.js";
 import { readTheme, readViewMode, readAutoCollapseViewed } from "../../config.js";
 import { createRequestHandler } from "./routes.js";
 import type { UIModelConfig, UIAction, UIServerHandle } from "./types.js";
 
 export type { ModelInfo, UIModelConfig, ActionType, CommentDecision, UIAction, UIServerHandle } from "./types.js";
+export type { ContextGroup } from "../../context.js";
 export { readTheme, readViewMode, readVerbose, readMinSeverity, readModel, readThinking, readDefaultBranch } from "../../config.js";
 
 const HEARTBEAT_MS = 45_000;
@@ -18,11 +20,12 @@ export async function startUIServer(
   source?: string,
   ssh?: boolean,
   modelConfig?: UIModelConfig,
+  contextGroups?: ContextGroup[],
 ): Promise<UIServerHandle> {
   const html = buildHTML(result, diff, source, ssh, readTheme(), readViewMode(), {
     ...modelConfig,
     autoCollapseViewed: readAutoCollapseViewed(),
-  });
+  }, contextGroups);
 
   let resolveAction!: (a: UIAction) => void;
   const actionPromise = new Promise<UIAction>((r) => { resolveAction = r; });

--- a/src/core/ui/template.ts
+++ b/src/core/ui/template.ts
@@ -3,12 +3,13 @@ import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import type { ReviewResult } from "../output.js";
 import type { UIModelConfig } from "./server/index.js";
+import type { ContextGroup } from "../context.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export function buildHTML(result: ReviewResult, diff: string, source?: string, ssh?: boolean, theme?: "dark" | "light", viewMode?: "split" | "unified", modelConfig?: UIModelConfig): string {
+export function buildHTML(result: ReviewResult, diff: string, source?: string, ssh?: boolean, theme?: "dark" | "light", viewMode?: "split" | "unified", modelConfig?: UIModelConfig, contextGroups?: ContextGroup[]): string {
   const templateHtml = readFileSync(join(__dirname, "../../../dist-ui/index.html"), "utf-8");
-  const escaped = JSON.stringify({ result, diff, source, ssh, theme, viewMode, ...modelConfig })
+  const escaped = JSON.stringify({ result, diff, source, ssh, theme, viewMode, ...modelConfig, contextGroups })
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")
     .replace(/&/g, "\\u0026");

--- a/tests/core/context.test.ts
+++ b/tests/core/context.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { loadContext, walkUpContextFiles, collectProviderContext, CONTEXT_PROVIDER_EVENT } from "../../src/core/context.js";
-import type { ContextProviderEvent, MinimalEventBus } from "../../src/core/context.js";
+import type { ContextProviderEvent, MinimalEventBus, ContextGroup } from "../../src/core/context.js";
 import { localFs } from "../../src/core/ssh.js";
 
 const createdDirs: string[] = [];
@@ -323,7 +323,7 @@ describe("collectProviderContext", () => {
     expect(provider).toHaveBeenCalledWith({ cwd: "/project", diffFiles: ["src/foo.ts"] });
   });
 
-  it("returns files from a registered provider", async () => {
+  it("returns a group with files from a registered provider", async () => {
     const events = createStubEventBus();
     events.on(CONTEXT_PROVIDER_EVENT, ({ register }: ContextProviderEvent) => {
       register("test-ext", async () => [{ path: "docs/arch.md", content: "Architecture" }]);
@@ -331,10 +331,12 @@ describe("collectProviderContext", () => {
 
     const result = await collectProviderContext(events, "/project", []);
 
-    expect(result).toEqual([{ path: "docs/arch.md", content: "Architecture" }]);
+    expect(result).toEqual<ContextGroup[]>([
+      { name: "test-ext", files: [{ path: "docs/arch.md", content: "Architecture" }] },
+    ]);
   });
 
-  it("flattens results from multiple providers", async () => {
+  it("returns one group per provider", async () => {
     const events = createStubEventBus();
     events.on(CONTEXT_PROVIDER_EVENT, ({ register }: ContextProviderEvent) => {
       register("ext-a", async () => [{ path: "docs/a.md", content: "A" }]);
@@ -344,8 +346,19 @@ describe("collectProviderContext", () => {
     const result = await collectProviderContext(events, "/project", []);
 
     expect(result).toHaveLength(2);
-    expect(result[0].path).toBe("docs/a.md");
-    expect(result[1].path).toBe("docs/b.md");
+    expect(result[0]).toEqual({ name: "ext-a", files: [{ path: "docs/a.md", content: "A" }] });
+    expect(result[1]).toEqual({ name: "ext-b", files: [{ path: "docs/b.md", content: "B" }] });
+  });
+
+  it("omits groups when provider returns empty array", async () => {
+    const events = createStubEventBus();
+    events.on(CONTEXT_PROVIDER_EVENT, ({ register }: ContextProviderEvent) => {
+      register("empty-ext", async () => []);
+    });
+
+    const result = await collectProviderContext(events, "/project", []);
+
+    expect(result).toHaveLength(0);
   });
 
   it("passes diffFiles so providers can filter by changed files", async () => {
@@ -361,7 +374,7 @@ describe("collectProviderContext", () => {
     const withMatch = await collectProviderContext(events, "/project", ["src/auth/login.ts"]);
     const withoutMatch = await collectProviderContext(events, "/project", ["src/utils.ts"]);
 
-    expect(withMatch).toHaveLength(1);
-    expect(withoutMatch).toHaveLength(0);
+    expect(withMatch).toHaveLength(1); // 1 group
+    expect(withoutMatch).toHaveLength(0); // filtered out (empty files)
   });
 });

--- a/tests/ui/context-panel-utils.test.ts
+++ b/tests/ui/context-panel-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { countContextFiles, flattenContextFiles } from "../../ui/src/context-panel-utils.js";
+import type { ContextGroup } from "../../ui/src/types.js";
+
+const groups: ContextGroup[] = [
+  {
+    name: "built-in",
+    files: [
+      { path: "AGENTS.md", content: "conventions" },
+      { path: "REVIEW.md", content: "rules" },
+    ],
+  },
+  {
+    name: "pi-context",
+    files: [{ path: "docs/arch.md", content: "arch docs" }],
+  },
+];
+
+describe("countContextFiles", () => {
+  it("returns 0 for empty groups", () => {
+    expect(countContextFiles([])).toBe(0);
+  });
+
+  it("returns total file count across all groups", () => {
+    expect(countContextFiles(groups)).toBe(3);
+  });
+
+  it("counts files in a single group", () => {
+    expect(countContextFiles([{ name: "a", files: [{ path: "f", content: "c" }] }])).toBe(1);
+  });
+
+  it("handles groups with no files", () => {
+    expect(countContextFiles([{ name: "empty", files: [] }])).toBe(0);
+  });
+});
+
+describe("flattenContextFiles", () => {
+  it("returns empty array for empty groups", () => {
+    expect(flattenContextFiles([])).toEqual([]);
+  });
+
+  it("preserves group name on each file", () => {
+    const flat = flattenContextFiles(groups);
+    expect(flat[0].group).toBe("built-in");
+    expect(flat[1].group).toBe("built-in");
+    expect(flat[2].group).toBe("pi-context");
+  });
+
+  it("preserves path and content", () => {
+    const flat = flattenContextFiles([{ name: "x", files: [{ path: "p", content: "c" }] }]);
+    expect(flat[0]).toEqual({ path: "p", content: "c", group: "x" });
+  });
+
+  it("flattens all groups into one array", () => {
+    expect(flattenContextFiles(groups)).toHaveLength(3);
+  });
+
+  it("returns files in group order", () => {
+    const flat = flattenContextFiles(groups);
+    expect(flat[0].path).toBe("AGENTS.md");
+    expect(flat[1].path).toBe("REVIEW.md");
+    expect(flat[2].path).toBe("docs/arch.md");
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,8 @@ import { FileTree, buildTree } from "./FileTree";
 import { ReviewHeader } from "./ReviewHeader";
 import { OrphanComments } from "./OrphanComments";
 import { SummaryPanel } from "./SummaryPanel";
+import { ContextPanel } from "./ContextPanel";
+import { SidePanelLayout } from "./SidePanelLayout";
 import { SettingsProvider } from "./SettingsContext";
 import { ScrollToTop } from "./ScrollToTop";
 
@@ -34,7 +36,7 @@ export default function App() {
 
   const [decisions, setDecisions] = useState<Record<number, DecisionState>>({});
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [summaryOpen, setSummaryOpen] = useState(false);
+  const [activePanel, setActivePanel] = useState<"summary" | "context" | null>(null);
   const [submitted, setSubmitted] = useState(false);
   const [theme, setTheme] = useState<"dark" | "light">(data.theme ?? "dark");
   const [viewedFiles, setViewedFiles] = useState<Record<string, boolean>>({});
@@ -107,6 +109,9 @@ export default function App() {
     {} as Record<string, number>
   );
 
+  const contextGroups = data.contextGroups ?? [];
+  const contextCount = contextGroups.reduce((n, g) => n + g.files.length, 0);
+
   const [allCollapsed, setAllCollapsed] = useState(false);
 
   function jumpToNextPending() {
@@ -174,7 +179,6 @@ export default function App() {
         onThemeToggle={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
         sidebarOpen={sidebarOpen}
         onSidebarToggle={() => setSidebarOpen((o) => !o)}
-        onSummaryToggle={() => setSummaryOpen((o) => !o)}
         decidedCount={decidedCount}
         totalComments={totalComments}
         allDone={allDone}
@@ -187,16 +191,21 @@ export default function App() {
         severityCounts={severityCounts}
         allCollapsed={allCollapsed}
         onToggleCollapse={() => setAllCollapsed((c) => !c)}
+        onSummaryToggle={() => setActivePanel((p) => (p === "summary" ? null : "summary"))}
+        onContextToggle={() => setActivePanel((p) => (p === "context" ? null : "context"))}
+        contextCount={contextCount > 0 ? contextCount : undefined}
       />
       <div id="layout">
         {sidebarOpen && (
-          <FileTree
-            tree={tree}
-            collapsedFolders={collapsedFolders}
-            toggleFolder={toggleFolder}
-            selectedFile={selectedFile}
-            onSelectFile={setSelectedFile}
-          />
+          <SidePanelLayout side="left">
+            <FileTree
+              tree={tree}
+              collapsedFolders={collapsedFolders}
+              toggleFolder={toggleFolder}
+              selectedFile={selectedFile}
+              onSelectFile={setSelectedFile}
+            />
+          </SidePanelLayout>
         )}
         <div id="files">
           {totalComments === 0 && (
@@ -233,8 +242,15 @@ export default function App() {
             onDecide={onDecide}
           />
         </div>
-        {summaryOpen && (
-          <SummaryPanel summary={result.summary} onClose={() => setSummaryOpen(false)} />
+        {activePanel && (
+          <SidePanelLayout>
+            {activePanel === "summary" && (
+              <SummaryPanel summary={result.summary} onClose={() => setActivePanel(null)} />
+            )}
+            {activePanel === "context" && (
+              <ContextPanel groups={contextGroups} onClose={() => setActivePanel(null)} />
+            )}
+          </SidePanelLayout>
         )}
       </div>
       <ScrollToTop />

--- a/ui/src/ContextFileItem.tsx
+++ b/ui/src/ContextFileItem.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+interface Props {
+  path: string;
+  content: string;
+}
+
+export function ContextFileItem({ path, content }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="ctx-file-item">
+      <button
+        className="ctx-file-path"
+        onClick={() => setExpanded(o => !o)}
+        aria-expanded={expanded}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="9 18 15 12 9 6"/>
+        </svg>
+        <span>{path}</span>
+      </button>
+      {expanded && <pre className="ctx-file-content">{content}</pre>}
+    </div>
+  );
+}

--- a/ui/src/ContextGroupSection.tsx
+++ b/ui/src/ContextGroupSection.tsx
@@ -1,0 +1,18 @@
+import { ContextFileItem } from "./ContextFileItem";
+import type { ContextFile } from "./types";
+
+interface Props {
+  name: string;
+  files: ContextFile[];
+}
+
+export function ContextGroupSection({ name, files }: Props) {
+  return (
+    <div className="ctx-group">
+      <div className="ctx-group-name">{name}</div>
+      {files.map(f => (
+        <ContextFileItem key={f.path} path={f.path} content={f.content} />
+      ))}
+    </div>
+  );
+}

--- a/ui/src/ContextPanel.tsx
+++ b/ui/src/ContextPanel.tsx
@@ -1,0 +1,24 @@
+import { SidePanel } from "./SidePanel";
+import { ContextGroupSection } from "./ContextGroupSection";
+import { countContextFiles } from "./context-panel-utils";
+import type { ContextGroup } from "./types";
+
+interface Props {
+  groups: ContextGroup[];
+  onClose: () => void;
+}
+
+export function ContextPanel({ groups, onClose }: Props) {
+  const total = countContextFiles(groups);
+  return (
+    <SidePanel title={`Context (${total} ${total === 1 ? "file" : "files"})`} onClose={onClose}>
+      {groups.length === 0 ? (
+        <p className="ctx-empty">No context files loaded.</p>
+      ) : (
+        groups.map(g => (
+          <ContextGroupSection key={g.name} name={g.name} files={g.files} />
+        ))
+      )}
+    </SidePanel>
+  );
+}

--- a/ui/src/ReviewHeader.tsx
+++ b/ui/src/ReviewHeader.tsx
@@ -22,6 +22,8 @@ interface ReviewHeaderProps {
   severityCounts?: Record<string, number>;
   allCollapsed: boolean;
   onToggleCollapse: () => void;
+  onContextToggle: () => void;
+  contextCount?: number;
 }
 
 export function ReviewHeader({
@@ -31,6 +33,7 @@ export function ReviewHeader({
   onJumpToNext, onAction, summary,
   currentModel, currentThinking,
   severityCounts, allCollapsed, onToggleCollapse,
+  onContextToggle, contextCount,
 }: ReviewHeaderProps) {
   const [submitOpen, setSubmitOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -118,6 +121,16 @@ export function ReviewHeader({
           ) : (
             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{display:"block"}}><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg>
           )}
+        </button>
+        <span id="hdr2-sep" />
+        <button className="icon-btn" onClick={onContextToggle} data-tooltip={contextCount ? `Context (${contextCount} files)` : "Context"}>
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{display:"block"}}>
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+            <line x1="16" y1="13" x2="8" y2="13"/>
+            <line x1="16" y1="17" x2="8" y2="17"/>
+            <polyline points="10 9 9 9 8 9"/>
+          </svg>
         </button>
         <span id="hdr2-sep" />
         <button className="icon-btn" onClick={onSummaryToggle} data-tooltip="Overview">

--- a/ui/src/SidePanel.tsx
+++ b/ui/src/SidePanel.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  title: ReactNode;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function SidePanel({ title, onClose, children }: Props) {
+  return (
+    <>
+      <div className="side-panel-hdr">
+        <span className="side-panel-title">{title}</span>
+        <button className="icon-btn" onClick={onClose} title="Close">
+          <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: "block" }}>
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+      <div className="side-panel-body">{children}</div>
+    </>
+  );
+}

--- a/ui/src/SidePanelLayout.tsx
+++ b/ui/src/SidePanelLayout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  side?: "left" | "right";
+  children: ReactNode;
+}
+
+export function SidePanelLayout({ side = "right", children }: Props) {
+  return <div className={`side-panel side-panel--${side}`}>{children}</div>;
+}

--- a/ui/src/SummaryPanel.tsx
+++ b/ui/src/SummaryPanel.tsx
@@ -1,22 +1,15 @@
 import { marked } from "marked";
+import { SidePanel } from "./SidePanel";
 
-interface SummaryPanelProps {
+interface Props {
   summary: string;
   onClose: () => void;
 }
 
-export function SummaryPanel({ summary, onClose }: SummaryPanelProps) {
+export function SummaryPanel({ summary, onClose }: Props) {
   return (
-    <div className="summary-panel">
-        <div className="summary-panel-hdr">
-          <span className="summary-panel-title">Overview</span>
-          <button className="icon-btn" onClick={onClose} title="Close">
-            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: "block" }}>
-              <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-            </svg>
-          </button>
-        </div>
-        <div className="summary-panel-body md" dangerouslySetInnerHTML={{ __html: marked(summary) as string }} />
-      </div>
+    <SidePanel title="Overview" onClose={onClose}>
+      <div className="summary-body md" dangerouslySetInnerHTML={{ __html: marked(summary) as string }} />
+    </SidePanel>
   );
 }

--- a/ui/src/context-panel-utils.ts
+++ b/ui/src/context-panel-utils.ts
@@ -1,0 +1,11 @@
+import type { ContextGroup, ContextFile } from "./types";
+
+export function countContextFiles(groups: ContextGroup[]): number {
+  return groups.reduce((n, g) => n + g.files.length, 0);
+}
+
+export function flattenContextFiles(
+  groups: ContextGroup[],
+): Array<ContextFile & { group: string }> {
+  return groups.flatMap(g => g.files.map(f => ({ ...f, group: g.name })));
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -435,13 +435,8 @@ body {
 
 /* ── File sidebar ────────────────────────────────────────────────────────── */
 #file-sidebar {
-  width: 296px;
-  flex-shrink: 0;
-  position: sticky;
-  top: 80px;
-  max-height: calc(100vh - 80px);
   overflow-y: auto;
-  border-right: 1px solid var(--border);
+  flex: 1;
   padding: 16px 0 8px;
 }
 
@@ -944,11 +939,10 @@ td.sign-ctx { background: var(--ctx-bg); color: var(--text-muted); }
   user-select: none;
 }
 
-/* ── Summary overview panel ──────────────────────────────────────────────── */
-.summary-panel {
-  width: 300px;
+/* ── Side panel shell (FileTree left, Summary/Context right) ─────────────── */
+.side-panel {
+  width: 296px;
   flex-shrink: 0;
-  border-left: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -958,7 +952,11 @@ td.sign-ctx { background: var(--ctx-bg); color: var(--text-muted); }
   max-height: calc(100vh - var(--hdr-h, 0px));
 }
 
-.summary-panel-hdr {
+.side-panel--left  { border-right: 1px solid var(--border); }
+.side-panel--right { border-left:  1px solid var(--border); }
+
+/* ── Shared side panel header + body ─────────────────────────────────────── */
+.side-panel-hdr {
   display: flex;
   align-items: center;
   padding: 10px 12px;
@@ -966,17 +964,88 @@ td.sign-ctx { background: var(--ctx-bg); color: var(--text-muted); }
   flex-shrink: 0;
 }
 
-.summary-panel-title {
+.side-panel-title {
   font-size: 13px;
   font-weight: 600;
   flex: 1;
 }
 
-.summary-panel-body {
-  padding: 16px;
+.side-panel-body {
   overflow-y: auto;
+  flex: 1;
+}
+
+/* ── Summary panel content ───────────────────────────────────────────────── */
+.summary-body {
+  padding: 16px;
   font-size: 13px;
   line-height: 1.6;
+}
+
+.ctx-empty {
+  padding: 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.ctx-group {
+  border-bottom: 1px solid var(--border);
+}
+
+.ctx-group-name {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 8px 12px 4px;
+}
+
+.ctx-file-item {
+  border-top: 1px solid var(--border-subtle, var(--border));
+}
+
+.ctx-file-path {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 12px;
+  font-family: var(--font-mono, monospace);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ctx-file-path:hover {
+  background: var(--bg-hover, var(--bg-subtle));
+}
+
+.ctx-file-path svg {
+  flex-shrink: 0;
+  transition: transform 0.15s;
+}
+
+.ctx-file-path[aria-expanded="true"] svg {
+  transform: rotate(90deg);
+}
+
+.ctx-file-content {
+  margin: 0;
+  padding: 8px 12px 8px 30px;
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: var(--bg-subtle);
+  border-top: 1px solid var(--border-subtle, var(--border));
+  max-height: 300px;
+  overflow-y: auto;
+  color: var(--text-muted);
 }
 
 /* ── Submit review panel ─────────────────────────────────────────────────── */

--- a/ui/src/mockData.ts
+++ b/ui/src/mockData.ts
@@ -280,6 +280,21 @@ export const mockData: UIData = {
   defaultModel: "openai-codex/gpt-5.4-mini",
   defaultThinking: "low",
   autoCollapseViewed: false,
+  contextGroups: [
+    {
+      name: "built-in",
+      files: [
+        { path: "AGENTS.md", content: "# Project conventions\n- Use strict TypeScript\n- All public functions must be typed\n- Prefer functional patterns over classes" },
+        { path: "REVIEW.md", content: "# Review rules\n- Always check error handling\n- Validate inputs at system boundaries" },
+      ],
+    },
+    {
+      name: "pi-context",
+      files: [
+        { path: "docs/architecture.md", content: "# Architecture\n\nThis project follows a layered architecture:\n1. Extensions layer (extensions/)\n2. Core layer (src/core/)\n3. CI layer (src/ci/)" },
+      ],
+    },
+  ],
   availableModels: [
     { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", provider: "openai-codex" },
     { id: "gpt-5.1-preview", name: "GPT-5.1 Preview", provider: "openai-codex" },

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,3 +1,13 @@
+export interface ContextFile {
+  path: string;
+  content: string;
+}
+
+export interface ContextGroup {
+  name: string;
+  files: ContextFile[];
+}
+
 export interface ReviewComment {
   file: string;
   line: number;
@@ -36,4 +46,5 @@ export interface UIData {
   availableModels?: ModelInfo[];
   defaultThinking?: string;
   autoCollapseViewed?: boolean;
+  contextGroups?: ContextGroup[];
 }


### PR DESCRIPTION
  - ContextGroup[] return type from collectProviderContext — one group per registered provider, empty groups filtered out
  - contextGroups threaded through template → startUIServer → UIData
  - SidePanelLayout: shared 296px sticky shell used by FileTree (left), Summary, and Context (right)
  - SidePanel: shared header (title + close) and body scroll wrapper
  - ContextPanel, ContextGroupSection, ContextFileItem: expandable file list grouped by provider name
  - context-panel-utils: pure countContextFiles / flattenContextFiles
  - Single activePanel state in App — only one right panel open at a time
  - ReviewHeader: context toggle button with file count tooltip
  - Tests: 9 unit tests for context-panel-utils, context.test.ts updated for new ContextGroup[] shape (344 passing)