### PR TITLE
fix(doc-context): walk up to gitRoot when --dir is used, thread gitRoot through provider API

### DIFF
--- a/extensions/pi-reviewer-doc-context/README.md
+++ b/extensions/pi-reviewer-doc-context/README.md
@@ -7,7 +7,7 @@ A pi extension that automatically injects relevant documentation from your proje
 At review time, the extension:
 
 1. Extracts keywords from the diff file paths (e.g. `src/auth/login.ts` → `auth`, `login`)
-2. Scans the configured doc dirs and one level of subdirectories for `.md` files with a `description` frontmatter field
+2. Scans the configured doc dirs from the project root down to the working directory, one level of subdirectories deep, for `.md` files with a `description` frontmatter field
 3. Loads any doc whose description or filename matches one of the keywords
 4. Injects the matching docs into the system prompt alongside `AGENTS.md` / `REVIEW.md`
 
@@ -35,7 +35,7 @@ Doc dirs and other settings are stored in `~/.pi/pi-reviewer-doc-context/config.
 
 | Field | Default | Description |
 |---|---|---|
-| `docDirs` | `[".pi/notes", ".claude/notes", ".agents/notes"]` | Directories to scan for doc files, relative to project root |
+| `docDirs` | `[".pi/notes", ".claude/notes", ".agents/notes"]` | Directories to scan for doc files, relative to each scanned directory |
 
 Each dir is scanned one level deep — files directly inside and files in immediate subdirectories are both picked up:
 
@@ -54,6 +54,21 @@ Example config:
 }
 ```
 
+### Monorepo and --dir
+
+When `/review --dir packages/app` is used, the extension scans doc dirs at every level from the repo root down to the target directory. Paths are expressed relative to the working directory:
+
+```
+repo/
+├── .pi/notes/shared.md         → ../../.pi/notes/shared.md  (from packages/app)
+└── packages/
+    ├── .pi/notes/common.md     → ../.pi/notes/common.md
+    └── app/
+        └── .pi/notes/local.md  → .pi/notes/local.md
+```
+
+All matched docs are included in the system prompt regardless of which level they come from.
+
 ---
 
 ## Context Provider API
@@ -67,7 +82,7 @@ pi-reviewer emits `"pi-reviewer:collect-context-providers"` on `pi.events` when 
 ```typescript
 pi.events.on("pi-reviewer:collect-context-providers", (data: unknown) => {
   const { cwd, diffFiles, register } = data as ContextProviderEvent;
-  register("my-extension", async ({ cwd, diffFiles, fs }) => {
+  register("my-extension", async ({ cwd, diffFiles, fs, gitRoot }) => {
     if (!diffFiles.some(f => f.startsWith("src/api/"))) return [];
     const content = await fs.read(fs.join(cwd, "docs/api.md"));
     if (!content) return [];
@@ -91,6 +106,7 @@ type ContextProvider = (opts: {
   cwd: string;
   diffFiles: string[]; // file paths from diff --git headers
   fs: Fs;              // filesystem abstraction — works locally and over SSH
+  gitRoot?: string;    // monorepo root; walk up from cwd to here when set (e.g. --dir is used)
 }) => Promise<ContextFile[]>;
 
 interface ContextProviderEvent {
@@ -104,6 +120,7 @@ interface Fs {
   read: (path: string) => Promise<string | null>;
   list: (path: string) => Promise<string[]>;
   join: (...parts: string[]) => string;
+  dirname: (path: string) => string;
 }
 ```
 
@@ -121,6 +138,31 @@ register("my-extension", async ({ cwd, diffFiles, fs }) => {
 ```
 
 Return `[]` to contribute nothing for this review.
+
+### Monorepo walk-up
+
+When `gitRoot` is provided, scan from the repo root down to `cwd` so docs at any level are included. Use `fs.dirname` to walk up from `cwd` to `gitRoot`:
+
+```typescript
+register("my-extension", async ({ cwd, diffFiles, fs, gitRoot }) => {
+  const results: ContextFile[] = [];
+  // Walk from gitRoot (or cwd when no gitRoot) down to cwd
+  const dirs: string[] = [];
+  let current = cwd;
+  while (true) {
+    dirs.unshift(current);
+    if (!gitRoot || current === gitRoot) break;
+    const parent = fs.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  for (const dir of dirs) {
+    const content = await fs.read(fs.join(dir, "docs/summary.md"));
+    if (content) results.push({ path: fs.join(dir, "docs/summary.md"), content });
+  }
+  return results;
+});
+```
 
 ### SSH mode
 

--- a/extensions/pi-reviewer-doc-context/index.ts
+++ b/extensions/pi-reviewer-doc-context/index.ts
@@ -11,6 +11,7 @@ interface Fs {
   read: (path: string) => Promise<string | null>;
   list: (path: string) => Promise<string[]>;
   join: (...parts: string[]) => string;
+  dirname: (path: string) => string;
 }
 
 interface ContextFile {
@@ -21,7 +22,7 @@ interface ContextFile {
 interface ContextProviderEvent {
   cwd: string;
   diffFiles: string[];
-  register: (name: string, provider: (opts: { cwd: string; diffFiles: string[]; fs: Fs }) => Promise<ContextFile[]>) => void;
+  register: (name: string, provider: (opts: { cwd: string; diffFiles: string[]; fs: Fs; gitRoot?: string }) => Promise<ContextFile[]>) => void;
 }
 
 function readDocDirs(): string[] {
@@ -64,6 +65,7 @@ async function scanDocFiles(
   cwd: string,
   fs: Fs,
   docDirs: string[],
+  gitRoot?: string,
 ): Promise<Array<{ path: string; content: string; description: string }>> {
   const results: Array<{ path: string; content: string; description: string }> = [];
 
@@ -87,20 +89,39 @@ async function scanDocFiles(
     }
   }
 
-  for (const dir of docDirs) {
-    await scanDir(fs.join(cwd, dir), dir, 0);
+  // Walk from cwd up to gitRoot (or just cwd when no gitRoot), root-first
+  const dirs: string[] = [];
+  let current = cwd;
+  while (true) {
+    dirs.unshift(current);
+    if (!gitRoot || current === gitRoot) break;
+    const parent = fs.dirname(current);
+    if (parent === current) break;
+    current = parent;
   }
+
+  for (let i = 0; i < dirs.length; i++) {
+    const dir = dirs[i];
+    const levelsUp = dirs.length - 1 - i;
+    const upParts = Array.from<string>({ length: levelsUp }).fill("..");
+    for (const docDir of docDirs) {
+      const absDocDir = fs.join(dir, docDir);
+      const relDocDir = levelsUp > 0 ? fs.join(...upParts, docDir) : docDir;
+      await scanDir(absDocDir, relDocDir, 0);
+    }
+  }
+
   return results;
 }
 
 export default function (pi: ExtensionAPI): void {
   pi.events.on(CONTEXT_PROVIDER_EVENT, (data: unknown) => {
     const { register } = data as ContextProviderEvent;
-    register("doc-context", async ({ cwd, diffFiles, fs }): Promise<ContextFile[]> => {
+    register("doc-context", async ({ cwd, diffFiles, fs, gitRoot }): Promise<ContextFile[]> => {
       const keywords = extractKeywords(diffFiles);
       if (keywords.length === 0) return [];
       const docDirs = readDocDirs();
-      const docs = await scanDocFiles(cwd, fs, docDirs);
+      const docs = await scanDocFiles(cwd, fs, docDirs, gitRoot);
       return docs
         .filter(doc => isRelevant(doc.description, doc.path, keywords))
         .map(doc => ({ path: doc.path, content: doc.content }));

--- a/extensions/pi-reviewer/handlers/context.ts
+++ b/extensions/pi-reviewer/handlers/context.ts
@@ -15,8 +15,9 @@ export async function buildContextGroups(
   context: ContextResult,
   diffFiles: string[],
   fs?: FsOps,
+  gitRoot?: string,
 ): Promise<ContextGroupsResult> {
-  const providerGroups = await collectProviderContext(events, cwd, diffFiles, fs);
+  const providerGroups = await collectProviderContext(events, cwd, diffFiles, fs, gitRoot);
   const contextFiles = providerGroups.flatMap(g => g.files);
   const builtInFiles = mergeContextFiles(context);
   const contextPaths = [...builtInFiles.map(f => f.path), ...contextFiles.map(f => f.path)];

--- a/extensions/pi-reviewer/handlers/local.ts
+++ b/extensions/pi-reviewer/handlers/local.ts
@@ -139,7 +139,10 @@ export async function handleLocalReview(opts: HandleLocalReviewOptions): Promise
   });
   const conventions = mergeContextFiles(context).map(f => f.content).join("\n\n");
   const diffFiles = extractDiffFiles(diff);
-  const { groups: allContextGroups, contextFiles, contextPaths } = await buildContextGroups(pi.events, ctx.cwd, context, diffFiles);
+  const providerCwd = parsed.dir ? path.resolve(ctx.cwd, parsed.dir) : ctx.cwd;
+  const { groups: allContextGroups, contextFiles, contextPaths } = await buildContextGroups(
+    pi.events, providerCwd, context, diffFiles, undefined, parsed.dir ? ctx.cwd : undefined,
+  );
   if (contextPaths.length > 0) notify(`Context: ${contextPaths.join(", ")}`);
 
   const systemPrompt = buildJSONSystemPrompt(context, minSeverity, contextFiles);

--- a/extensions/pi-reviewer/handlers/ssh.ts
+++ b/extensions/pi-reviewer/handlers/ssh.ts
@@ -138,8 +138,9 @@ export async function handleSSHReview(opts: HandleSSHReviewOptions): Promise<voi
   if (sshDiffWarning) notify(sshDiffWarning, "warning");
 
   const sshDiffFiles = extractDiffFiles(rawSshDiff);
+  const sshGitRoot = parsed.dir ? (sshState ? sshState.remoteCwd : ctx.cwd) : undefined;
   const { groups: sshAllContextGroups, contextFiles: sshContextFiles, contextPaths: allSshContextPaths } =
-    await buildContextGroups(pi.events, sshRemoteCwd, sshContext, sshDiffFiles, providerFs);
+    await buildContextGroups(pi.events, sshRemoteCwd, sshContext, sshDiffFiles, providerFs, sshGitRoot);
   if (allSshContextPaths.length > 0) notify(`Context: ${allSshContextPaths.join(", ")}`);
 
   const userPrompt = buildUserPrompt(sshDiff, sshSkippedFiles);

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -25,7 +25,7 @@ export interface ContextResult {
 
 export const CONTEXT_PROVIDER_EVENT = "pi-reviewer:collect-context-providers";
 
-export type ContextProvider = (opts: { cwd: string; diffFiles: string[]; fs: FsOps }) => Promise<ContextFile[]>;
+export type ContextProvider = (opts: { cwd: string; diffFiles: string[]; fs: FsOps; gitRoot?: string }) => Promise<ContextFile[]>;
 
 export interface ContextProviderEvent {
   cwd: string;
@@ -113,6 +113,7 @@ export async function collectProviderContext(
   cwd: string,
   diffFiles: string[],
   fs: FsOps = localFs(),
+  gitRoot?: string,
 ): Promise<ContextGroup[]> {
   const registrations: Array<{ name: string; provider: ContextProvider }> = [];
   events.emit(CONTEXT_PROVIDER_EVENT, {
@@ -123,7 +124,7 @@ export async function collectProviderContext(
   const groups = await Promise.all(
     registrations.map(async ({ name, provider }) => ({
       name,
-      files: await provider({ cwd, diffFiles, fs }),
+      files: await provider({ cwd, diffFiles, fs, gitRoot }),
     })),
   );
   const merged = new Map<string, ContextFile[]>();

--- a/tests/extension/handlers/context.test.ts
+++ b/tests/extension/handlers/context.test.ts
@@ -69,6 +69,6 @@ describe("buildContextGroups", () => {
   it("passes fs argument through to collectProviderContext", async () => {
     const fakeFs = { read: vi.fn(), list: vi.fn(), join: vi.fn(), dirname: vi.fn(), relative: vi.fn() } as any;
     await buildContextGroups(stubEvents, "/project", emptyContext, ["src/x.ts"], fakeFs);
-    expect(collectProviderContext).toHaveBeenCalledWith(stubEvents, "/project", ["src/x.ts"], fakeFs);
+    expect(collectProviderContext).toHaveBeenCalledWith(stubEvents, "/project", ["src/x.ts"], fakeFs, undefined);
   });
 });

--- a/tests/extension/handlers/local.test.ts
+++ b/tests/extension/handlers/local.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", async (importActual) => {
@@ -202,5 +203,33 @@ describe("handleLocalReview — context paths notify", () => {
     await handleLocalReview(opts);
     const contextCall = opts.notify.mock.calls.find(c => String(c[0]).startsWith("Context:"));
     expect(contextCall).toBeUndefined();
+  });
+});
+
+describe("handleLocalReview — --dir cwd routing", () => {
+  it("passes nested dir as cwd and ctx.cwd as gitRoot when --dir is set", async () => {
+    const opts = makeOpts({ dir: "packages/app" });
+    await handleLocalReview(opts);
+    expect(buildContextGroups).toHaveBeenCalledWith(
+      expect.anything(),
+      path.resolve("/project", "packages/app"),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      "/project",
+    );
+  });
+
+  it("passes ctx.cwd as cwd and undefined gitRoot when --dir is not set", async () => {
+    const opts = makeOpts();
+    await handleLocalReview(opts);
+    expect(buildContextGroups).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      undefined,
+    );
   });
 });

--- a/tests/extension/handlers/ssh.test.ts
+++ b/tests/extension/handlers/ssh.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../../extensions/pi-reviewer/handlers/ui.js", () => ({
   handleUIReview: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { collectProviderContext } from "../../../src/core/context.js";
 import { setReviewFooter } from "../../../extensions/pi-reviewer/footer.js";
 import { handleUIReview } from "../../../extensions/pi-reviewer/handlers/ui.js";
 import { handleSSHReview } from "../../../extensions/pi-reviewer/handlers/ssh.js";
@@ -82,8 +83,10 @@ function makeSyncAgentEndPi() {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.mocked(setReviewFooter).mockReturnValue(vi.fn());
   vi.mocked(handleUIReview).mockResolvedValue(undefined);
+  vi.mocked(collectProviderContext).mockResolvedValue([]);
 });
 
 describe("handleSSHReview — non-UI path (sshState = null)", () => {
@@ -113,6 +116,32 @@ describe("handleSSHReview — non-UI path (sshState = null)", () => {
     const opts = makeOpts();
     await handleSSHReview(opts);
     expect(setReviewFooter).toHaveBeenCalledWith(ctx, expect.any(String), expect.any(Object));
+  });
+});
+
+describe("handleSSHReview — gitRoot propagation (sshState = null)", () => {
+  it("passes undefined gitRoot when --dir is not set", async () => {
+    const opts = makeOpts();
+    await handleSSHReview(opts);
+    expect(collectProviderContext).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.any(Array),
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it("passes ctx.cwd as gitRoot when --dir is set", async () => {
+    const opts = makeOpts({ dir: "packages/app" });
+    await handleSSHReview(opts);
+    expect(collectProviderContext).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.any(Array),
+      expect.anything(),
+      "/project",
+    );
   });
 });
 

--- a/tests/extensions/doc-context-provider.test.ts
+++ b/tests/extensions/doc-context-provider.test.ts
@@ -1,4 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importActual) => {
+  const actual = await importActual<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn().mockImplementation((path: unknown, ...args: unknown[]) => {
+      if (String(path).includes("pi-reviewer-doc-context")) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return (actual.readFileSync as (path: unknown, ...args: unknown[]) => unknown)(path, ...args);
+    }),
+  };
+});
+
+import registerExtension from "../../extensions/pi-reviewer-doc-context/index.js";
 import { extractKeywords, parseDescription, isRelevant } from "../../extensions/pi-reviewer-doc-context/index.js";
 
 describe("extractKeywords", () => {
@@ -95,5 +110,117 @@ describe("isRelevant", () => {
 
   it("matches on any keyword, not all", () => {
     expect(isRelevant("Token expiry policy", "tokens.md", ["auth", "token", "deploy"])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Walk-up behaviour via provider capture
+// ---------------------------------------------------------------------------
+
+const CONTEXT_PROVIDER_EVENT = "pi-reviewer:collect-context-providers";
+
+function makeFakeFsOps(files: Record<string, string>) {
+  return {
+    read: async (p: string): Promise<string | null> => files[p] ?? null,
+    list: async (p: string): Promise<string[]> => {
+      const prefix = p.endsWith("/") ? p : `${p}/`;
+      const seen = new Set<string>();
+      for (const key of Object.keys(files)) {
+        if (key.startsWith(prefix)) {
+          const segment = key.slice(prefix.length).split("/")[0];
+          if (segment) seen.add(segment);
+        }
+      }
+      return [...seen];
+    },
+    join: (...parts: string[]) => parts.join("/").replace(/\/+/g, "/"),
+    dirname: (p: string) => {
+      const i = p.lastIndexOf("/");
+      return i <= 0 ? "/" : p.slice(0, i);
+    },
+  };
+}
+
+function captureProvider() {
+  const handlers = new Map<string, Array<(data: unknown) => void>>();
+  const events = {
+    emit(channel: string, data: unknown) { for (const h of handlers.get(channel) ?? []) h(data); },
+    on(channel: string, handler: (data: unknown) => void) {
+      if (!handlers.has(channel)) handlers.set(channel, []);
+      handlers.get(channel)!.push(handler);
+      return () => {};
+    },
+  };
+
+  registerExtension({ events } as any);
+
+  let captured: ((opts: { cwd: string; diffFiles: string[]; fs: any; gitRoot?: string }) => Promise<{ path: string; content: string }[]>) | null = null;
+  events.emit(CONTEXT_PROVIDER_EVENT, {
+    cwd: "",
+    diffFiles: [],
+    register: (_name: string, provider: typeof captured) => { captured = provider; },
+  });
+
+  if (!captured) throw new Error("Provider was not registered");
+  return captured;
+}
+
+const docContent = (description: string) =>
+  `---\ndescription: ${description}\n---\n# Guide\n\ncontent`;
+
+describe("doc-context provider — walk-up (gitRoot)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("without gitRoot only scans cwd — parent doc not found", async () => {
+    const provider = captureProvider();
+    const fs = makeFakeFsOps({
+      "/repo/.pi/notes/deploy.md": docContent("deploy pipeline"),
+      "/repo/app/.pi/notes/auth.md": docContent("auth token handling"),
+    });
+    const files = await provider({ cwd: "/repo/app", diffFiles: ["deploy.ts", "auth.ts"], fs });
+    const paths = files.map(f => f.path);
+    expect(paths).toContain(".pi/notes/auth.md");
+    expect(paths).not.toContain("../.pi/notes/deploy.md");
+  });
+
+  it("with gitRoot finds doc at parent level", async () => {
+    const provider = captureProvider();
+    const fs = makeFakeFsOps({
+      "/repo/.pi/notes/deploy.md": docContent("deploy pipeline"),
+      "/repo/app/.pi/notes/auth.md": docContent("auth token handling"),
+    });
+    const files = await provider({ cwd: "/repo/app", diffFiles: ["deploy.ts", "auth.ts"], fs, gitRoot: "/repo" });
+    const paths = files.map(f => f.path);
+    expect(paths).toContain(".pi/notes/auth.md");
+    expect(paths).toContain("../.pi/notes/deploy.md");
+  });
+
+  it("parent doc path uses ../ prefix", async () => {
+    const provider = captureProvider();
+    const fs = makeFakeFsOps({
+      "/repo/.pi/notes/deploy.md": docContent("deploy pipeline"),
+    });
+    const files = await provider({ cwd: "/repo/app", diffFiles: ["deploy.ts"], fs, gitRoot: "/repo" });
+    expect(files[0]?.path).toBe("../.pi/notes/deploy.md");
+  });
+
+  it("returns empty when diffFiles is empty (no keywords)", async () => {
+    const provider = captureProvider();
+    const fs = makeFakeFsOps({
+      "/repo/.pi/notes/auth.md": docContent("auth token handling"),
+    });
+    const files = await provider({ cwd: "/repo", diffFiles: [], fs, gitRoot: "/repo" });
+    expect(files).toHaveLength(0);
+  });
+
+  it("irrelevant docs are filtered out", async () => {
+    const provider = captureProvider();
+    const fs = makeFakeFsOps({
+      "/repo/app/.pi/notes/deploy.md": docContent("deploy pipeline"),
+    });
+    const files = await provider({ cwd: "/repo/app", diffFiles: ["auth.ts"], fs });
+    expect(files).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Two bugs with SSH/local --dir: local.ts passed the repo root as cwd to
  buildContextGroups instead of the nested dir, so provider context always
  scanned from the wrong location. scanDocFiles only scanned cwd, so docs
  at parent/root level were never found in a monorepo.

  Fix: thread gitRoot through collectProviderContext → ContextProvider opts;
  in local.ts pass providerCwd = resolved nested dir + gitRoot = ctx.cwd;
  in ssh.ts compute sshGitRoot from sshState or ctx.cwd when --dir is set;
  scanDocFiles now walks from cwd up to gitRoot (root-first) and computes
  relative paths with ../ prefixes.

  Also adds dirname to the Fs interface and tests covering walk-up behavior,
  correct cwd routing in handleLocalReview, and gitRoot propagation in
  handleSSHReview.
