### PR TITLE
fix(ui): context UX polish — one file per line and blue icon

### DIFF
--- a/extensions/pi-reviewer/handlers/local.ts
+++ b/extensions/pi-reviewer/handlers/local.ts
@@ -145,7 +145,7 @@ export async function handleLocalReview(opts: HandleLocalReviewOptions): Promise
   const { groups: allContextGroups, contextFiles, contextPaths } = await buildContextGroups(
     pi.events, providerCwd, context, diffFiles, undefined, parsed.dir ? ctx.cwd : undefined,
   );
-  if (contextPaths.length > 0) notify(`Context: ${contextPaths.join(", ")}`);
+  if (contextPaths.length > 0) notify(`Context:\n${contextPaths.map((p) => `  ${p}`).join("\n")}`);
 
   const systemPrompt = buildJSONSystemPrompt(context, minSeverity, contextFiles);
   const userPrompt = buildUserPrompt(diff, skippedFiles);

--- a/extensions/pi-reviewer/handlers/ssh.ts
+++ b/extensions/pi-reviewer/handlers/ssh.ts
@@ -143,7 +143,7 @@ export async function handleSSHReview(opts: HandleSSHReviewOptions): Promise<voi
   const sshGitRoot = parsed.dir ? (sshState ? sshState.remoteCwd : ctx.cwd) : undefined;
   const { groups: sshAllContextGroups, contextFiles: sshContextFiles, contextPaths: allSshContextPaths } =
     await buildContextGroups(pi.events, sshRemoteCwd, sshContext, sshDiffFiles, providerFs, sshGitRoot);
-  if (allSshContextPaths.length > 0) notify(`Context: ${allSshContextPaths.join(", ")}`);
+  if (allSshContextPaths.length > 0) notify(`Context:\n${allSshContextPaths.map((p) => `  ${p}`).join("\n")}`);
 
   const userPrompt = buildUserPrompt(sshDiff, sshSkippedFiles);
 

--- a/ui/src/ReviewHeader.tsx
+++ b/ui/src/ReviewHeader.tsx
@@ -127,7 +127,7 @@ export function ReviewHeader({
           )}
         </button>
         <span id="hdr2-sep" />
-        <button className="icon-btn" onClick={onContextToggle} data-tooltip={contextCount ? `Context (${contextCount} files)` : "Context"}>
+        <button className="icon-btn icon-btn--active" onClick={onContextToggle} data-tooltip={contextCount ? `Context (${contextCount} files)` : "Context"}>
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{display:"block"}}>
             <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
             <polyline points="14 2 14 8 20 8"/>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -260,6 +260,14 @@ body {
   color: var(--text);
 }
 
+.icon-btn--active {
+  color: var(--link);
+}
+
+.icon-btn--active:hover:not(:disabled) {
+  color: var(--link);
+}
+
 .icon-btn:disabled {
   opacity: .35;
   cursor: not-allowed;


### PR DESCRIPTION
  - Context notify now prints one file per line (indented) instead of a comma-separated list; easier to scan on long path lists
  - Context icon-btn is always --link blue (not state-dependent) to signal it as the entry point for injected context