### PR TITLE
fix(ci): pin action SHAs & add Renovate with 7-day cooldown

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,19 @@
+{
+  // NOTE: Renovate reads this config from the default branch (main), not from PR branches.
+  // To test changes to this file in a PR, the branch name should be 'renovate/reconfigure'
+  // so renovate will pick up the modifications to renovate.json5 during the PR workflow run.
+  // https://docs.renovatebot.com/getting-started/installing-onboarding/#reconfigure-via-pr
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "prHourlyLimit": 2,
+  "commitMessageExtra": "from {{#if currentVersion}}{{{currentVersion}}}{{else}}{{{currentDigestShort}}}{{/if}} to {{#if newVersion}}{{{newVersion}}}{{else}}{{{newDigestShort}}}{{/if}}",
+  "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  // config:recommended already pins github-actions to commit SHAs via
+  // helpers:pinGitHubActionDigests, so the action.yml pins stay updated.
+  "enabledManagers": ["npm", "github-actions"]
+}

--- a/action.yml
+++ b/action.yml
@@ -44,14 +44,14 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
         version: 11.8.0
         run_install: false
 
     - name: Setup Node
       if: ${{ inputs.setup-node == 'true' }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
 
@@ -65,7 +65,7 @@ runs:
 
     - name: Cache pnpm store
       if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       continue-on-error: true
       with:
         path: ${{ steps.pnpm-meta.outputs.store-path }}

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Setup Node
       if: ${{ inputs.setup-node == 'true' }}
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
 
@@ -65,7 +65,7 @@ runs:
 
     - name: Cache pnpm store
       if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       continue-on-error: true
       with:
         path: ${{ steps.pnpm-meta.outputs.store-path }}


### PR DESCRIPTION
## Problem

GitHub lets you enforce a security policy that **all third-party GitHub Actions must be pinned to a full-length commit SHA**. `pi-reviewer` is consumed as a composite action, but `action.yml` uses floating tags:

```
uses: pnpm/action-setup@v6
uses: actions/setup-node@v6
uses: actions/cache@v5
```

This prevents its use with that (desirable) security setting.

## Fix — pin to commit SHAs

Pinned all three to recent releases (commit SHAs resolved via the git object API, annotated-tag aware, and verified as real commits — not tag-object SHAs). Version retained in a trailing comment for readability.

| Action | Tag | Commit SHA | Verify |
| --- | --- | --- | --- |
| `pnpm/action-setup` | v6.0.9 | `0ebf47130e4866e96fce0953f49152a61190b271` | [release](https://github.com/pnpm/action-setup/releases/tag/v6.0.9) · [commit](https://github.com/pnpm/action-setup/commit/0ebf47130e4866e96fce0953f49152a61190b271) |
| `actions/setup-node` | v6.4.0 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | [release](https://github.com/actions/setup-node/releases/tag/v6.4.0) · [commit](https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e) |
| `actions/cache` | v6.1.0 | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | [release](https://github.com/actions/cache/releases/tag/v6.1.0) · [commit](https://github.com/actions/cache/commit/55cc8345863c7cc4c66a329aec7e433d2d1c52a9) |

> Note: `actions/cache` was bumped from the existing `@v5` floating tag to the latest major `v6.1.0` (published 2026-06-23). If a v5 constraint is preferred, say so and it can be pinned to `v5.1.0` (`caa296126883cff596d87d8935842f9db880ef25`) instead.

## Renovate to keep the pins updated

Adds `.github/renovate.json5` so the SHA pins (and npm deps) stay current without manual upkeep:

- **`config:recommended`** — pulls in `helpers:pinGitHubActionDigests`, so the commit-SHA pins in `action.yml` are maintained automatically.
- **`minimumReleaseAge: "7 days"`** — a stability + supply-chain cooldown. Renovate will not offer an update until the release is 7 days old, giving freshly-published (or freshly-yanked-malicious) releases time to be caught before a PR is opened. Vulnerability fixes bypass this via `vulnerabilityAlerts` so security patches are not delayed.
- **`enabledManagers: ["npm", "github-actions"]`** — scoped to the two ecosystems this repo actually uses.

## ⚠️ Activation note for the maintainer

The config file alone does **not** run Renovate. To activate, a repo admin needs to **install the Renovate GitHub App** on `zeflq/pi-reviewer` (https://github.com/apps/renovate). Once installed, Renovate reads this config from the default branch and begins managing updates. No workflow file or PAT is required for the hosted-App route.

## Validation

- `action.yml` diffs are SHA-only, no behavioral change (cache major bump aside).
- All three SHAs verified as 40-char real commits via `repos/.../git/refs/tags` (+ `git/tags` for annotated tags).
- `.github/renovate.json5` parsed as valid JSON5 (comment + trailing-comma tolerant).
