### PR TITLE
fix: Drop committed `dist/src/**` — run TypeScript directly in the GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         PI_REVIEWER_MODEL: ${{ inputs.model }}
         MIN_SEVERITY: ${{ inputs.min-severity }}
         PI_REVIEWER_DOC_DIRS: ${{ inputs.doc-dirs }}
-      run: node ${{ github.action_path }}/dist/src/ci/action-entry.js
+      run: tsx ${{ github.action_path }}/src/ci/action-entry.ts
 
 branding:
   icon: "eye"


### PR DESCRIPTION
Closes #53

Patch generated by `qwen3.6-35b-a3b via local API`.